### PR TITLE
Bump version to 2.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>io.cryostat</groupId>
 <artifactId>cryostat-core</artifactId>
-<version>2.3.0-SNAPSHOT</version>
+<version>2.2.3</version>
 <packaging>jar</packaging>
 <name>cryostat-core</name>
 <url>http://maven.apache.org</url>


### PR DESCRIPTION
The version was previously set to `2.3.0-SNAPSHOT`, however the last tag was on `2.2.2`. This "bumps" it to `2.2.3` and will be the first tagged version after the Cryostat rename. The plan is to start using `SNAPSHOT` versions for development, however for simplicity's sake it will be easier to finish the rename of the Crysotat main project with a `2.2.3` tagged version here first.