### PR TITLE
feat(reports): Add JFR event for report rules

### DIFF
--- a/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
+++ b/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
@@ -69,6 +69,11 @@ import org.openjdk.jmc.flightrecorder.rules.report.html.internal.RulesHtmlToolki
 
 import io.cryostat.core.log.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import jdk.jfr.Category;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
 import org.jsoup.Jsoup;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -228,11 +233,15 @@ public class InterruptibleReportGenerator {
             callables.add(
                     () -> {
                         logger.trace("Processing rule {}", rule.getName());
-                        // TODO it would be very nice to record a JFR event here to pick up in
-                        // Cryostat's own profiling template, to compare the different rule
-                        // implementations and the time they each take to process with various
-                        // source recording settings
+                        ReportRuleEvalEvent evt = new ReportRuleEvalEvent(rule.getName());
+                        evt.begin();
+
                         result.run();
+
+                        evt.end();
+                        if (evt.shouldCommit()) {
+                            evt.commit();
+                        }
                         return result.get();
                     });
         }
@@ -345,6 +354,21 @@ public class InterruptibleReportGenerator {
         @Override
         public Collection<String> getTopics() {
             return topics;
+        }
+    }
+
+    @Name("io.cryostat.core.reports.InterruptibleReportGenerator.ReportRuleEvalEvent")
+    @Label("Report Rule Evaluation")
+    @Category("Cryostat")
+    @SuppressFBWarnings(
+            value = "URF_UNREAD_FIELD",
+            justification = "The event fields are recorded with JFR instead of accessed directly")
+    public static class ReportRuleEvalEvent extends Event {
+
+        String ruleName;
+
+        ReportRuleEvalEvent(String ruleName) {
+            this.ruleName = ruleName;
         }
     }
 }

--- a/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
+++ b/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
@@ -236,13 +236,15 @@ public class InterruptibleReportGenerator {
                         ReportRuleEvalEvent evt = new ReportRuleEvalEvent(rule.getName());
                         evt.begin();
 
-                        result.run();
-
-                        evt.end();
-                        if (evt.shouldCommit()) {
-                            evt.commit();
+                        try {
+                            result.run();
+                            return result.get();
+                        } finally {
+                            evt.end();
+                            if (evt.shouldCommit()) {
+                                evt.commit();
+                            }
                         }
-                        return result.get();
                     });
         }
         return callables;


### PR DESCRIPTION
Fixes #117

Question: How do I test this change with my other branch in `~/cryostat`? I tried the below commands on my `record-rule-event` branches, started smoketest, started a new recording on `service:jmx:rmi:///jndi/rmi://cryostat:10000/jmxrmi` with the updated Cryostat template, generated a report, then downloaded the recording. I couldn't find any instances of my custom event in the recording file with `jfr print <recording_name>.jfr | vim -`. What am I missing?

```
~/cryostat-core $ mvn install
~/cryostat-core $ cd ~/cryostat
~/cryostat $ mvn clean package && CRYOSTAT_DISABLE_SSL=true CRYOSTAT_DISABLE_JMX_AUTH=true sh smoketest.sh
```