### PR TITLE
build(version): set version to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>io.cryostat</groupId>
 <artifactId>cryostat-core</artifactId>
-<version>2.8.0</version>
+<version>2.9.0</version>
 <packaging>jar</packaging>
 <name>cryostat-core</name>
 <url>http://maven.apache.org</url>


### PR DESCRIPTION
Related https://github.com/cryostatio/cryostat/issues/566

> Oh, we'll also need a -core minor version release cut and the pom.xml here updated to point to that new version.

_Originally posted by @andrewazores in https://github.com/cryostatio/cryostat/issues/855#issuecomment-1064473901_