### PR TITLE
chore(pom): set version to 2.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>io.cryostat</groupId>
 <artifactId>cryostat-core</artifactId>
-<version>2.9.0</version>
+<version>2.9.1</version>
 <packaging>jar</packaging>
 <name>cryostat-core</name>
 <url>http://maven.apache.org</url>


### PR DESCRIPTION
#132 bugfix PR has been merged and backported, so this PR bumps the version to prep for tagging as 2.9.1 to use in the main Cryostat 2.1 release branch.