### PR TITLE
chore(pom): set version to 2.10.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>io.cryostat</groupId>
 <artifactId>cryostat-core</artifactId>
-<version>2.9.0</version>
+<version>2.10.0-SNAPSHOT</version>
 <packaging>jar</packaging>
 <name>cryostat-core</name>
 <url>http://maven.apache.org</url>


### PR DESCRIPTION
Currently in `main` the `pom` version is still 2.9.0, which matches the latest git tag but also matches the `cryostat-v2.1` branch. This sets it to `2.10.0-SNAPSHOT` for the start of the next development iteration.