### PR TITLE
feat(reports): report generator allows callers to specify which rules to evaluate

### DIFF
--- a/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
+++ b/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
@@ -111,13 +111,13 @@ public class InterruptibleReportGenerator {
 
     public Future<ReportResult> generateReportInterruptibly(
             InputStream recording, Predicate<IRule> predicate) {
+        Objects.requireNonNull(recording);
+        Objects.requireNonNull(predicate);
         return qThread.submit(
                 () -> {
                     // this is generally a re-implementation of JMC JfrHtmlRulesReport#createReport,
                     // but calling our cancellable evalute() method rather than the
                     // RulesToolkit.evaluateParallel as explained further down.
-                    Objects.requireNonNull(predicate);
-                    Objects.requireNonNull(recording);
                     List<Future<Result>> resultFutures = new ArrayList<>();
                     try (CountingInputStream countingRecordingStream =
                             new CountingInputStream(recording)) {

--- a/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
+++ b/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
@@ -113,13 +113,14 @@ public class InterruptibleReportGenerator {
             InputStream recording, Predicate<IRule> predicate) {
         return qThread.submit(
                 () -> {
+                    // this is generally a re-implementation of JMC JfrHtmlRulesReport#createReport,
+                    // but calling our cancellable evalute() method rather than the
+                    // RulesToolkit.evaluateParallel as explained further down.
+                    Objects.requireNonNull(predicate);
+                    Objects.requireNonNull(recording);
                     List<Future<Result>> resultFutures = new ArrayList<>();
                     try (CountingInputStream countingRecordingStream =
                             new CountingInputStream(recording)) {
-                        Objects.requireNonNull(predicate);
-                        Objects.requireNonNull(recording);
-                        // RuleRegistry.getRules().stream()
-                        //         .forEach(r -> System.out.println(String.format("TOPIC: {%s}", r.getTopic())));
                         Collection<IRule> rules =
                                 RuleRegistry.getRules().stream()
                                         .filter(predicate)
@@ -148,7 +149,6 @@ public class InterruptibleReportGenerator {
                                                 true));
                         long recordingSizeBytes = countingRecordingStream.getByteCount();
                         int rulesEvaluated = results.size();
-                        // System.out.println(String.format("Size {%d}", rulesEvaluated));
                         int rulesApplicable =
                                 results.stream()
                                         .filter(

--- a/src/test/java/io/cryostat/core/reports/InterruptibleReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/core/reports/InterruptibleReportGeneratorTest.java
@@ -98,6 +98,22 @@ class InterruptibleReportGeneratorTest {
     }
 
     @Test
+    void shouldThrowNullRecording() throws Exception {
+        Assertions.assertThrows(NullPointerException.class, () -> {
+                generator.generateReportInterruptibly(null).get();
+        });
+    }
+
+    @Test
+    void shouldThrowNullPredicate() throws Exception {
+        try (InputStream is = new FileInputStream(getJfrFile())) {
+                Assertions.assertThrows(NullPointerException.class, () -> {
+                        generator.generateReportInterruptibly(is, null).get();
+                });
+        }
+    }
+
+    @Test
     void shouldProduceReportWithFilteredRules() throws Exception {
         try (InputStream is = new FileInputStream(getJfrFile())) {
             Future<ReportResult> report =

--- a/src/test/java/io/cryostat/core/reports/InterruptibleReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/core/reports/InterruptibleReportGeneratorTest.java
@@ -99,17 +99,21 @@ class InterruptibleReportGeneratorTest {
 
     @Test
     void shouldThrowNullRecording() throws Exception {
-        Assertions.assertThrows(NullPointerException.class, () -> {
-                generator.generateReportInterruptibly(null).get();
-        });
+        Assertions.assertThrows(
+                NullPointerException.class,
+                () -> {
+                    generator.generateReportInterruptibly(null).get();
+                });
     }
 
     @Test
     void shouldThrowNullPredicate() throws Exception {
         try (InputStream is = new FileInputStream(getJfrFile())) {
-                Assertions.assertThrows(NullPointerException.class, () -> {
+            Assertions.assertThrows(
+                    NullPointerException.class,
+                    () -> {
                         generator.generateReportInterruptibly(is, null).get();
-                });
+                    });
         }
     }
 

--- a/src/test/java/io/cryostat/core/reports/InterruptibleReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/core/reports/InterruptibleReportGeneratorTest.java
@@ -113,6 +113,25 @@ class InterruptibleReportGeneratorTest {
     }
 
     @Test
+    void shouldProduceReportWithFilteredRulesAndTopics() throws Exception {
+        try (InputStream is = new FileInputStream(getJfrFile())) {
+            Future<ReportResult> report =
+                    generator.generateReportInterruptibly(
+                            is,
+                            rule ->
+                                    rule.getId() == "ClassLeak"
+                                            || rule.getId() == "SystemGc"
+                                            || rule.getTopic() == "garbage_collection");
+            MatcherAssert.assertThat(
+                    report.get().getHtml(), Matchers.not(Matchers.emptyOrNullString()));
+            MatcherAssert.assertThat(
+                    report.get().getReportStats(), Matchers.not(Matchers.nullValue()));
+            MatcherAssert.assertThat(
+                    report.get().getReportStats().rulesEvaluated, Matchers.equalTo(10));
+        }
+    }
+
+    @Test
     void shouldProduceEmptyReport() throws Exception {
         try (InputStream is = new FileInputStream(getJfrFile())) {
             Future<ReportResult> report =


### PR DESCRIPTION
Related to #136

Not sure if this is all we need to allow callers to specify rules because all it is, is a method overload with an extra parameter added. Feedback is appreciated.

I was thinking maybe if the Collection of rules is empty or null that there would be some custom exception that would need to be implemented? But I am also confused as to how to test cryostat-core implementations in general.