### PR TITLE
feat(jmx): compute unique jvm id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
   <com.mycila.license.maven.plugin.version>4.0</com.mycila.license.maven.plugin.version>
 
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>
+  <org.apache.commons.codec.version>1.15</org.apache.commons.codec.version>
   <org.apache.commons.io.version>2.11.0</org.apache.commons.io.version>
   <org.apache.commons.text.version>1.9</org.apache.commons.text.version>
   <org.jsoup.version>1.14.2</org.jsoup.version>
@@ -72,6 +73,11 @@
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-lang3</artifactId>
     <version>${org.apache.commons.lang3.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>commons-codec</groupId>
+    <artifactId>commons-codec</artifactId>
+    <version>${org.apache.commons.codec.version}</version>
   </dependency>
   <dependency>
     <groupId>commons-io</groupId>

--- a/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -186,7 +186,7 @@ public class JFRConnection implements AutoCloseable {
                 } else {
                     throw new IllegalArgumentException(
                             String.format(
-                                    "Unexpected attribute class of %s", attrObject.getClass()));
+                                    "Unexpected attribute: {%s} of type: {%s}", attr, attrObject.getClass()));
                 }
             }
             byte[] hash = DigestUtils.sha256(baos.toByteArray());

--- a/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -76,7 +76,6 @@ import io.cryostat.core.templates.TemplateService;
 import io.cryostat.core.tui.ClientWriter;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.ArrayUtils;
 
 public class JFRConnection implements AutoCloseable {
 
@@ -186,10 +185,8 @@ public class JFRConnection implements AutoCloseable {
                         this.rjmxConnection.getAttributeValue(
                                 new MRI(Type.ATTRIBUTE, ConnectionToolkit.RUNTIME_BEAN_NAME, attr));
                 if (attrObject.getClass().isArray()) {
-                    if (attrObject.getClass().getComponentType().isPrimitive()) {
-                        attrObject = castPrimitiveToObject(attrObject);
-                    }
-                    dos.writeUTF(Arrays.toString((Object[]) attrObject));
+                    String stringified = stringifyArray(attrObject);
+                    dos.writeUTF(stringified);
                 } else {
                     dos.writeUTF(attrObject.toString());
                 }
@@ -199,47 +196,46 @@ public class JFRConnection implements AutoCloseable {
         }
     }
 
-    private synchronized Object[] castPrimitiveToObject(Object primitiveObject) {
-        Object[] objArr;
-        String componentType = primitiveObject.getClass().getComponentType().toString();
+    private String stringifyArray(Object arrayObject) {
+        String stringified;
+        String componentType = arrayObject.getClass().getComponentType().toString();
         switch (componentType) {
             case "boolean":
-                objArr = ArrayUtils.toObject((boolean[]) primitiveObject);
+                stringified = Arrays.toString((boolean[]) arrayObject);
                 break;
 
             case "byte":
-                objArr = ArrayUtils.toObject((byte[]) primitiveObject);
+                stringified = Arrays.toString((byte[]) arrayObject);
                 break;
 
             case "char":
-                objArr = ArrayUtils.toObject((char[]) primitiveObject);
+                stringified = Arrays.toString((char[]) arrayObject);
                 break;
 
             case "short":
-                objArr = ArrayUtils.toObject((short[]) primitiveObject);
+                stringified = Arrays.toString((short[]) arrayObject);
                 break;
 
             case "int":
-                objArr = ArrayUtils.toObject((int[]) primitiveObject);
+                stringified = Arrays.toString((int[]) arrayObject);
                 break;
 
             case "long":
-                objArr = ArrayUtils.toObject((long[]) primitiveObject);
+                stringified = Arrays.toString((long[]) arrayObject);
                 break;
 
             case "float":
-                objArr = ArrayUtils.toObject((float[]) primitiveObject);
+                stringified = Arrays.toString((float[]) arrayObject);
                 break;
 
             case "double":
-                objArr = ArrayUtils.toObject((double[]) primitiveObject);
+                stringified = Arrays.toString((double[]) arrayObject);
                 break;
 
             default:
-                throw new IllegalStateException(
-                        String.format("Unexpected primitive array of type %s", componentType));
+                stringified = Arrays.toString((Object[]) arrayObject);
         }
-        return objArr;
+        return stringified;
     }
 
     public synchronized boolean isV1() {

--- a/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -202,40 +202,42 @@ public class JFRConnection implements AutoCloseable {
     private synchronized Object[] castPrimitiveToObject(Object primitiveObject) {
         Object[] objArr;
         String componentType = primitiveObject.getClass().getComponentType().toString();
-        switch(componentType) {
+        switch (componentType) {
             case "boolean":
-                objArr = ArrayUtils.toObject((boolean []) primitiveObject);
+                objArr = ArrayUtils.toObject((boolean[]) primitiveObject);
                 break;
-                
+
             case "byte":
-                objArr = ArrayUtils.toObject((byte []) primitiveObject);
+                objArr = ArrayUtils.toObject((byte[]) primitiveObject);
                 break;
 
             case "char":
-                objArr = ArrayUtils.toObject((char []) primitiveObject);
+                objArr = ArrayUtils.toObject((char[]) primitiveObject);
                 break;
 
             case "short":
-                objArr = ArrayUtils.toObject((short []) primitiveObject);
+                objArr = ArrayUtils.toObject((short[]) primitiveObject);
                 break;
-            
+
             case "int":
-                objArr = ArrayUtils.toObject((int []) primitiveObject);
+                objArr = ArrayUtils.toObject((int[]) primitiveObject);
+                break;
 
             case "long":
-                objArr = ArrayUtils.toObject((long []) primitiveObject);
+                objArr = ArrayUtils.toObject((long[]) primitiveObject);
                 break;
-            
+
             case "float":
-                objArr = ArrayUtils.toObject((float []) primitiveObject);
+                objArr = ArrayUtils.toObject((float[]) primitiveObject);
                 break;
-            
+
             case "double":
-                objArr = ArrayUtils.toObject((double []) primitiveObject);
+                objArr = ArrayUtils.toObject((double[]) primitiveObject);
                 break;
-                
+
             default:
-                throw new IllegalStateException(String.format("Unexpected primitive array of type %s", componentType));
+                throw new IllegalStateException(
+                        String.format("Unexpected primitive array of type %s", componentType));
         }
         return objArr;
     }

--- a/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -148,6 +148,10 @@ public class JFRConnection implements AutoCloseable {
         }
     }
 
+    public synchronized String getGUID() {
+        return this.rjmxConnection.getServerDescriptor().getGUID();
+    }
+
     public synchronized boolean isV1() {
         return !isV2();
     }

--- a/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -161,7 +161,9 @@ public class JFRConnection implements AutoCloseable {
         }
     }
 
-    public synchronized String getJvmId() throws AttributeNotFoundException, InstanceNotFoundException, MBeanException, ReflectionException, IOException {
+    public synchronized String getJvmId()
+            throws AttributeNotFoundException, InstanceNotFoundException, MBeanException,
+                    ReflectionException, IOException {
         if (!isConnected()) {
             connect();
         }
@@ -182,15 +184,10 @@ public class JFRConnection implements AutoCloseable {
                 Object attrObject =
                         this.rjmxConnection.getAttributeValue(
                                 new MRI(Type.ATTRIBUTE, ConnectionToolkit.RUNTIME_BEAN_NAME, attr));
-
-                if (attrObject instanceof String || attrObject instanceof Long) {
-                    dos.writeUTF(attrObject.toString());
-                } else if (attrObject instanceof String[]) {
+                if (attrObject.getClass().isArray()) {
                     dos.writeUTF(Arrays.toString((String[]) attrObject));
                 } else {
-                    throw new IllegalArgumentException(
-                            String.format(
-                                    "Unexpected attribute: {%s} of type: {%s}", attr, attrObject.getClass()));
+                    dos.writeUTF(attrObject.toString());
                 }
             }
             byte[] hash = DigestUtils.sha256(baos.toByteArray());

--- a/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -47,6 +47,10 @@ import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.ReflectionException;
 import javax.management.remote.JMXServiceURL;
 
 import org.openjdk.jmc.rjmx.ConnectionException;
@@ -157,7 +161,7 @@ public class JFRConnection implements AutoCloseable {
         }
     }
 
-    public synchronized String getJvmId() throws Exception {
+    public synchronized String getJvmId() throws AttributeNotFoundException, InstanceNotFoundException, MBeanException, ReflectionException, IOException {
         if (!isConnected()) {
             connect();
         }

--- a/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -186,7 +186,7 @@ public class JFRConnection implements AutoCloseable {
                         this.rjmxConnection.getAttributeValue(
                                 new MRI(Type.ATTRIBUTE, ConnectionToolkit.RUNTIME_BEAN_NAME, attr));
                 if (attrObject.getClass().isArray()) {
-                    if (!attrObject.getClass().getComponentType().isPrimitive()) {
+                    if (attrObject.getClass().getComponentType().isPrimitive()) {
                         attrObject = castPrimitiveToObject(attrObject);
                     }
                     dos.writeUTF(Arrays.toString((Object[]) attrObject));

--- a/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -174,17 +174,17 @@ public class JFRConnection implements AutoCloseable {
                                 "VmVersion",
                                 "StartTime"));
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
-        DataOutputStream dos = new DataOutputStream(baos);
-
-        for (String attr : attrNames) {
-            dos.writeUTF(
-                    this.rjmxConnection
-                            .getAttributeValue(new MRI(Type.ATTRIBUTE, runtimeBean, attr))
-                            .toString());
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
+                DataOutputStream dos = new DataOutputStream(baos)) {
+            for (String attr : attrNames) {
+                dos.writeUTF(
+                        this.rjmxConnection
+                                .getAttributeValue(new MRI(Type.ATTRIBUTE, runtimeBean, attr))
+                                .toString());
+            }
+            byte[] hash = DigestUtils.sha256(baos.toByteArray());
+            return new String(Base64.getUrlEncoder().encode(hash), StandardCharsets.UTF_8).trim();
         }
-        byte[] hash = DigestUtils.sha256(baos.toByteArray());
-        return new String(Base64.getUrlEncoder().encode(hash), StandardCharsets.UTF_8).trim();
     }
 
     public synchronized boolean isV1() {

--- a/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -43,12 +43,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.management.AttributeNotFoundException;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanException;
-import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-import javax.management.ReflectionException;
 import javax.management.remote.JMXServiceURL;
 
 import org.openjdk.jmc.rjmx.ConnectionException;
@@ -161,6 +156,9 @@ public class JFRConnection implements AutoCloseable {
 
     public synchronized int getJvmId() {
         try {
+            if (!isConnected()) {
+                connect();
+            }
             ObjectName runtimeBean = new ObjectName("java.lang:type=Runtime");
             List<String> attributes =
                     new ArrayList<>(
@@ -180,12 +178,7 @@ public class JFRConnection implements AutoCloseable {
                                 new MRI(Type.ATTRIBUTE, runtimeBean, attr)));
             }
             return jvmId.hashCode();
-        } catch (MalformedObjectNameException
-                | IOException
-                | AttributeNotFoundException
-                | InstanceNotFoundException
-                | MBeanException
-                | ReflectionException e) {
+        } catch (Exception e) {
             cw.println(e);
             return 0;
         }


### PR DESCRIPTION
Related https://github.com/cryostatio/cryostat/issues/960
Related https://github.com/cryostatio/cryostat-web/issues/442

~~Adds a getter that returns the JFRConnection server descriptor's GUID.~~

Adds a getter that computes a hashcode based on jvm runtime properties.