### PR TITLE
chore(pom): update to JDK17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
     - uses: skjolber/maven-cache-github-action@v1
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
         server-id: github
         settings-path: ${{ github.workspace }}

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ JFR with JDK Mission Control API
 ## Requirements
 Build:
 - Maven
-- JDK11+
+- JDK17+
 
 ## Build
 

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,7 @@
           <googleJavaFormat>
             <version>1.15.0</version>
             <style>AOSP</style>
+            <reflowLongStrings>true</reflowLongStrings>
           </googleJavaFormat>
           <trimTrailingWhitespace/>
           <endWithNewline/>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <java.version>11</java.version>
+  <java.version>17</java.version>
   <maven.compiler.target>${java.version}</maven.compiler.target>
   <maven.compiler.source>${java.version}</maven.compiler.source>
   <jmc.version>7.1.1</jmc.version>
@@ -39,11 +39,11 @@
 
   <com.github.spotbugs.version>4.2.3</com.github.spotbugs.version>
   <com.github.spotbugs.plugin.version>4.2.3</com.github.spotbugs.plugin.version>
-  <org.junit.jupiter.version>5.7.1</org.junit.jupiter.version>
+  <org.junit.jupiter.version>5.8.2</org.junit.jupiter.version>
   <org.hamcrest.version>2.2</org.hamcrest.version>
-  <org.mockito.version>3.9.0</org.mockito.version>
-  <org.jacoco.maven.plugin.version>0.8.6</org.jacoco.maven.plugin.version>
-  <com.diffplug.spotless.maven.plugin.version>2.10.1</com.diffplug.spotless.maven.plugin.version>
+  <org.mockito.version>4.6.1</org.mockito.version>
+  <org.jacoco.maven.plugin.version>0.8.8</org.jacoco.maven.plugin.version>
+  <com.diffplug.spotless.maven.plugin.version>2.22.6</com.diffplug.spotless.maven.plugin.version>
   <org.slf4j.version>1.7.35</org.slf4j.version>
 </properties>
 
@@ -210,7 +210,7 @@
             <exclude>src/main/java/org/openjdk/jmc/**</exclude>
           </excludes>
           <googleJavaFormat>
-            <version>1.7</version>
+            <version>1.15.0</version>
             <style>AOSP</style>
           </googleJavaFormat>
           <trimTrailingWhitespace/>

--- a/src/main/java/io/cryostat/core/agent/LocalProbeTemplateService.java
+++ b/src/main/java/io/cryostat/core/agent/LocalProbeTemplateService.java
@@ -67,7 +67,8 @@ public class LocalProbeTemplateService implements ProbeTemplateService {
         if (!env.hasEnv(TEMPLATE_PATH)) {
             throw new IOException(
                     String.format(
-                            "Probe template directory does not exist, must be set using environment variable %s",
+                            "Probe template directory does not exist, must be set using environment"
+                                    + " variable %s",
                             TEMPLATE_PATH));
         }
         // Sanity check the directory is set up correctly
@@ -78,7 +79,8 @@ public class LocalProbeTemplateService implements ProbeTemplateService {
                 || !fs.isWritable(probeTemplateDirectory)) {
             throw new IOException(
                     String.format(
-                            "Probe template directory %s does not exist, is not a directory, or has incorrect permissions.",
+                            "Probe template directory %s does not exist, is not a directory, or has"
+                                    + " incorrect permissions.",
                             probeTemplateDirectory.toString()));
         }
     }

--- a/src/main/java/io/cryostat/core/sys/Clock.java
+++ b/src/main/java/io/cryostat/core/sys/Clock.java
@@ -42,7 +42,9 @@ import java.util.concurrent.TimeUnit;
 
 public class Clock {
 
-    /** @deprecated Use #now() */
+    /**
+     * @deprecated Use #now()
+     */
     @Deprecated
     public long getWallTime() {
         return System.currentTimeMillis();

--- a/src/main/java/io/cryostat/core/templates/LocalStorageTemplateService.java
+++ b/src/main/java/io/cryostat/core/templates/LocalStorageTemplateService.java
@@ -93,14 +93,16 @@ public class LocalStorageTemplateService extends AbstractTemplateService
         if (!env.hasEnv(TEMPLATE_PATH)) {
             throw new IOException(
                     String.format(
-                            "Template directory does not exist, must be set using environment variable %s",
+                            "Template directory does not exist, must be set using environment"
+                                    + " variable %s",
                             TEMPLATE_PATH));
         }
         Path dir = fs.pathOf(env.getEnv(TEMPLATE_PATH));
         if (!fs.exists(dir) || !fs.isDirectory(dir) || !fs.isReadable(dir) || !fs.isWritable(dir)) {
             throw new IOException(
                     String.format(
-                            "Template directory %s does not exist, is not a directory, or does not have appropriate permissions",
+                            "Template directory %s does not exist, is not a directory, or does not"
+                                    + " have appropriate permissions",
                             dir.toString()));
         }
         try (templateStream) {
@@ -159,14 +161,16 @@ public class LocalStorageTemplateService extends AbstractTemplateService
         if (!env.hasEnv(TEMPLATE_PATH)) {
             throw new IOException(
                     String.format(
-                            "Template directory does not exist, must be set using environment variable %s",
+                            "Template directory does not exist, must be set using environment"
+                                    + " variable %s",
                             TEMPLATE_PATH));
         }
         Path dir = fs.pathOf(env.getEnv(TEMPLATE_PATH));
         if (!fs.exists(dir) || !fs.isDirectory(dir) || !fs.isReadable(dir) || !fs.isWritable(dir)) {
             throw new IOException(
                     String.format(
-                            "Template directory %s does not exist, is not a directory, or does not have appropriate permissions",
+                            "Template directory %s does not exist, is not a directory, or does not"
+                                    + " have appropriate permissions",
                             dir.toString()));
         }
         if (!fs.deleteIfExists(fs.pathOf(env.getEnv(TEMPLATE_PATH), templateName))) {

--- a/src/test/java/io/cryostat/core/EventOptionsCustomizerTest.java
+++ b/src/test/java/io/cryostat/core/EventOptionsCustomizerTest.java
@@ -160,7 +160,8 @@ class EventOptionsCustomizerTest {
         MatcherAssert.assertThat(
                 e.getMessage(),
                 Matchers.equalTo(
-                        "Invalid value \"fooVal\" for event \"com.example.FooType\", option \"fooOption\""));
+                        "Invalid value \"fooVal\" for event \"com.example.FooType\", option"
+                                + " \"fooOption\""));
     }
 
     @Test

--- a/src/test/java/io/cryostat/core/RecordingOptionsCustomizerTest.java
+++ b/src/test/java/io/cryostat/core/RecordingOptionsCustomizerTest.java
@@ -39,7 +39,7 @@ package io.cryostat.core;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.openjdk.jmc.common.unit.QuantityConversionException;
@@ -73,7 +73,7 @@ class RecordingOptionsCustomizerTest {
         customizer.apply(builder);
         verify(builder).toDisk(true);
         verifyNoMoreInteractions(builder);
-        verifyZeroInteractions(cw);
+        verifyNoInteractions(cw);
     }
 
     @Test
@@ -82,7 +82,7 @@ class RecordingOptionsCustomizerTest {
         customizer.apply(builder);
         verify(builder).maxAge(123);
         verifyNoMoreInteractions(builder);
-        verifyZeroInteractions(cw);
+        verifyNoInteractions(cw);
     }
 
     @Test
@@ -92,7 +92,7 @@ class RecordingOptionsCustomizerTest {
         customizer.apply(builder);
         verify(builder).maxAge(456);
         verifyNoMoreInteractions(builder);
-        verifyZeroInteractions(cw);
+        verifyNoInteractions(cw);
     }
 
     @Test
@@ -101,7 +101,7 @@ class RecordingOptionsCustomizerTest {
         customizer.apply(builder);
         verify(builder).maxSize(123);
         verifyNoMoreInteractions(builder);
-        verifyZeroInteractions(cw);
+        verifyNoInteractions(cw);
     }
 
     @Test
@@ -110,7 +110,7 @@ class RecordingOptionsCustomizerTest {
         customizer.unset(RecordingOptionsCustomizer.OptionKey.MAX_SIZE);
         customizer.apply(builder);
         verifyNoMoreInteractions(builder);
-        verifyZeroInteractions(cw);
+        verifyNoInteractions(cw);
     }
 
     @Test

--- a/src/test/java/io/cryostat/core/RecordingOptionsCustomizerTest.java
+++ b/src/test/java/io/cryostat/core/RecordingOptionsCustomizerTest.java
@@ -38,8 +38,8 @@
 package io.cryostat.core;
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.openjdk.jmc.common.unit.QuantityConversionException;

--- a/src/test/java/io/cryostat/core/reports/ReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/core/reports/ReportGeneratorTest.java
@@ -87,7 +87,7 @@ class ReportGeneratorTest {
         MatcherAssert.assertThat(report, Matchers.is(SAMPLE_REPORT));
 
         Mockito.verify(reporter).apply(Mockito.any());
-        Mockito.verifyZeroInteractions(logger);
+        Mockito.verifyNoInteractions(logger);
     }
 
     @Test
@@ -127,7 +127,7 @@ class ReportGeneratorTest {
                                 + "</html>"));
 
         Mockito.verify(reporter).apply(Mockito.any());
-        Mockito.verifyZeroInteractions(logger);
+        Mockito.verifyNoInteractions(logger);
     }
 
     @Test
@@ -173,7 +173,7 @@ class ReportGeneratorTest {
                                 + "</html>"));
 
         Mockito.verify(reporter).apply(Mockito.any());
-        Mockito.verifyZeroInteractions(logger);
+        Mockito.verifyNoInteractions(logger);
     }
 
     @Test
@@ -254,6 +254,6 @@ class ReportGeneratorTest {
                                 + "</html>"));
 
         Mockito.verify(reporter).apply(Mockito.any());
-        Mockito.verifyZeroInteractions(logger);
+        Mockito.verifyNoInteractions(logger);
     }
 }

--- a/src/test/java/io/cryostat/core/reports/ReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/core/reports/ReportGeneratorTest.java
@@ -118,13 +118,13 @@ class ReportGeneratorTest {
                 report,
                 Matchers.is(
                         "<html>\n"
-                                + " <head></head>\n"
-                                + " <body>\n"
-                                + "  <div class=\"foo\">\n"
-                                + "   <a id=\"hl\" href=\"http://example.com\">new description</a>\n"
-                                + "  </div>\n"
-                                + " </body>\n"
-                                + "</html>"));
+                            + " <head></head>\n"
+                            + " <body>\n"
+                            + "  <div class=\"foo\">\n"
+                            + "   <a id=\"hl\" href=\"http://example.com\">new description</a>\n"
+                            + "  </div>\n"
+                            + " </body>\n"
+                            + "</html>"));
 
         Mockito.verify(reporter).apply(Mockito.any());
         Mockito.verifyNoInteractions(logger);

--- a/src/test/java/io/cryostat/core/templates/LocalStorageTemplateServiceTest.java
+++ b/src/test/java/io/cryostat/core/templates/LocalStorageTemplateServiceTest.java
@@ -111,7 +111,8 @@ class LocalStorageTemplateServiceTest {
                         Collections.singletonList(
                                 new Template(
                                         "Profiling",
-                                        "Low overhead configuration for profiling, typically around 2 % overhead.",
+                                        "Low overhead configuration for profiling, typically around"
+                                                + " 2 % overhead.",
                                         "Oracle",
                                         TemplateType.CUSTOM))));
     }
@@ -221,7 +222,8 @@ class LocalStorageTemplateServiceTest {
         MatcherAssert.assertThat(
                 t.getDescription(),
                 Matchers.equalTo(
-                        "Low overhead configuration for profiling, typically around 2 % overhead."));
+                        "Low overhead configuration for profiling, typically around 2 %"
+                                + " overhead."));
         MatcherAssert.assertThat(t.getProvider(), Matchers.equalTo("Oracle"));
         MatcherAssert.assertThat(t.getType(), Matchers.equalTo(TemplateType.CUSTOM));
     }

--- a/src/test/java/io/cryostat/core/templates/RemoteTemplateServiceTest.java
+++ b/src/test/java/io/cryostat/core/templates/RemoteTemplateServiceTest.java
@@ -85,7 +85,8 @@ class RemoteTemplateServiceTest {
                         Collections.singletonList(
                                 new Template(
                                         "Profiling",
-                                        "Low overhead configuration for profiling, typically around 2 % overhead.",
+                                        "Low overhead configuration for profiling, typically around"
+                                                + " 2 % overhead.",
                                         "Oracle",
                                         TemplateType.TARGET))));
     }


### PR DESCRIPTION
Fixes #137

The `.mvn/jvm.config` file is needed for now as a workaround on https://github.com/diffplug/spotless/issues/834 . One Mockito static method has been removed so it was replaced with an equivalent. Everything else is pretty routine.
