### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/FlightRecorderServiceV2.java
+++ b/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/FlightRecorderServiceV2.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The contents of this file are subject to the terms of either the Universal Permissive License
@@ -10,17 +10,17 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions
  * and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
  * conditions and the following disclaimer in the documentation and/or other materials provided with
  * the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
@@ -125,6 +125,7 @@ public class FlightRecorderServiceV2 implements IFlightRecorderService {
 	}
 
 	public FlightRecorderServiceV2(IConnectionHandle handle) throws ConnectionException, ServiceNotAvailableException {
+        connection = handle;
 		cfs = handle.getServiceOrThrow(ICommercialFeaturesService.class);
 		if (!isDynamicFlightRecorderSupported(handle) && isFlightRecorderDisabled(handle)) {
 			throw new ServiceNotAvailableException(""); //$NON-NLS-1$
@@ -132,7 +133,6 @@ public class FlightRecorderServiceV2 implements IFlightRecorderService {
 		if (JVMSupportToolkit.isFlightRecorderDisabled(handle, true)) {
 			throw new ServiceNotAvailableException(""); //$NON-NLS-1$
 		}
-		connection = handle;
 		helper = new FlightRecorderCommunicationHelperV2(handle.getServiceOrThrow(MBeanServerConnection.class));
 		mbhs = handle.getServiceOrThrow(IMBeanHelperService.class);
 		serverId = handle.getServerDescriptor().getGUID();


### PR DESCRIPTION
### Summary
Fixes a NPE encountered when attempting to connect with a non-hotspot VM.

### Problem Description
See error stack trace [here](https://gist.github.com/roberttoyonaga/9149882f08a4ce031fa8aea3c03b516e).

NPE occurs because `FlightRecorderServiceV2.connection` is not initialized before use. This can happen in the `FlightRecorderServiceV2` constructor when `isDynamicFlightRecorderSupported(IConnectionHandle)` returns `false` because it calls `ConnectionToolkit.isHotSpot(IConnectionHandle)` which returns `false` for native images.  This allows `isFlightRecorderDisabled(IConnectionHandle)` to be evaluated which results in the stack trace linked above. 

### Solution
Initialize `FlightRecorderServiceV2.connection` earlier.