### PR TITLE
chore(build): target JDK 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'adopt'
     - uses: skjolber/maven-cache-github-action@v1
       with:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ JFR with JDK Mission Control API
 ## Requirements
 Build:
 - Maven
-- JDK17+
+- JDK11+
 
 ## Build
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <java.version>17</java.version>
+  <java.version>11</java.version>
   <maven.compiler.target>${java.version}</maven.compiler.target>
   <maven.compiler.source>${java.version}</maven.compiler.source>
   <jmc.version>7.1.1</jmc.version>


### PR DESCRIPTION
The cryostat-agent has some use cases for -core, such as being able to compute its own JVM ID. The agent targets JDK 11 for wider compatibility, so -core should target 11 as well as the lowest common denominator.