### PR TITLE
build(github): publish JAR to GH pkgs on release

### DIFF
--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -1,0 +1,41 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: skjolber/maven-cache-github-action@v1
+      with:
+        step: restore
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B -U package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - uses: skjolber/maven-cache-github-action@v1
+      with:
+        step: save

--- a/README.md
+++ b/README.md
@@ -14,3 +14,36 @@ Build:
 
 `mvn install` to compile this core library and publish the artifacts to the
 local Maven repository for consumption by other projects.
+
+Consumers of this build may pull it from the GitHub Packages registry. This
+registry requires authentication.
+
+Add or merge the following configuration into your `$HOME/.m2/settings.xml`,
+creating the file if it does not exist:
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>github-cryostat-core</id>
+      <username>$MY_GITHUB_USERNAME</username>
+      <password>$MY_GITHUB_ACCESSTOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+The token must have the `read:packages` permission. It is recommended that this
+is the *only* permission the token has.
+
+Then, add the following to your build's `pom.xml`:
+
+```xml
+<repositories>
+  <repository>
+    <id>github-cryostat-core</id>
+    <url>https://maven.pkg.github.com/cryostatio/cryostat-core</url>
+  </repository>
+</repositories>
+```


### PR DESCRIPTION
Related to #92

Config is directly copied from the `-agent` repo where it's already set up and seems to be working (my `quarkus-test` consumes that). Machines where builds consuming this artifact will be run will need a Maven configuration as follows:

https://github.com/andrewazores/quarkus-test#packaging-and-running-the-application

Since this is on release only, there would be no `-SNAPSHOT` builds available for consumers. Not sure if we want to bother with that now and build/publish a `-SNAPSHOT` every time there is a merge to `main`. I think that can probably wait until later on if we decide this works well enough.