### PR TITLE
chore(ci): use temurin distribution jdk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/1401

See https://github.com/actions/setup-java#supported-distributions

Update ci to use `temurin` jdk.