### PR TITLE
fix(fs): close directory file descriptor

### DIFF
--- a/src/main/java/io/cryostat/core/sys/FileSystem.java
+++ b/src/main/java/io/cryostat/core/sys/FileSystem.java
@@ -50,6 +50,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class FileSystem {
 
@@ -95,7 +96,9 @@ public class FileSystem {
     }
 
     public List<String> listDirectoryChildren(Path path) throws IOException {
-        return Files.list(path).map(p -> p.getFileName().toString()).collect(Collectors.toList());
+        try (Stream<Path> stream = Files.list(path)) {
+            return stream.map(p -> p.getFileName().toString()).collect(Collectors.toList());
+        }
     }
 
     public boolean deleteIfExists(Path path) throws IOException {


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/1444

The FileSystem wrapper around `java.nio.file.Files` fails to close the `Stream<Path>` it opens when listing directory contents. This class is dependency-injected in Cryostat (for testing mock ease) and used in several frequently called codepaths. This leaking fd adds up quite quickly as Cryostat runs and serves requests.
