### PR TITLE
ci(mergify): update config for 2.3 release branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,11 @@
 pull_request_rules:
-  - name: backport patches to cryostat-v2.2 branch
+  - name: backport patches to cryostat-v2.3 branch
     conditions:
       - base=main
       - label=backport
     actions:
       backport:
         branches:
-          - cryostat-v2.2
+          - cryostat-v2.3
         assignees:
           - "{{ author }}"


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/1459

Missing mergify update for release branching.