### PR TITLE
chore(jmc-agent): clean up probe template utility

### DIFF
--- a/src/main/java/io/cryostat/core/agent/LocalProbeTemplateService.java
+++ b/src/main/java/io/cryostat/core/agent/LocalProbeTemplateService.java
@@ -87,18 +87,19 @@ public class LocalProbeTemplateService implements ProbeTemplateService {
         }
     }
 
-    public void addTemplate(InputStream inputStream, String filename)
+    public ProbeTemplate addTemplate(InputStream inputStream, String filename)
             throws FileAlreadyExistsException, IOException, SAXException {
+        Path path = fs.pathOf(env.getEnv(TEMPLATE_PATH), filename);
+        if (fs.exists(path)) {
+            throw new FileAlreadyExistsException(filename);
+        }
         try (inputStream) {
             ProbeTemplate template = new ProbeTemplate();
             template.setFileName(filename);
             // If validation fails this will throw a ProbeValidationException with details
             template.deserialize(inputStream);
-            Path path = fs.pathOf(env.getEnv(TEMPLATE_PATH), filename);
-            if (fs.exists(path)) {
-                throw new FileAlreadyExistsException(template.getFileName());
-            }
             fs.writeString(path, template.serialize());
+            return template;
         }
     }
 
@@ -138,8 +139,8 @@ public class LocalProbeTemplateService implements ProbeTemplateService {
                         Path fileName = path.getFileName();
                         if (fileName != null) {
                             ProbeTemplate template = new ProbeTemplate();
-                            template.deserialize(stream);
                             template.setFileName(fileName.toString());
+                            template.deserialize(stream);
                             templates.add(template);
                         }
                     }

--- a/src/main/java/io/cryostat/core/agent/LocalProbeTemplateService.java
+++ b/src/main/java/io/cryostat/core/agent/LocalProbeTemplateService.java
@@ -91,7 +91,8 @@ public class LocalProbeTemplateService implements ProbeTemplateService {
             throws FileAlreadyExistsException, IOException, SAXException {
         Path path = fs.pathOf(env.getEnv(TEMPLATE_PATH), filename);
         if (fs.exists(path)) {
-            throw new FileAlreadyExistsException(filename);
+            throw new FileAlreadyExistsException(
+                    String.format("Probe template \"%s\" already exists.", filename));
         }
         try (inputStream) {
             ProbeTemplate template = new ProbeTemplate();

--- a/src/main/java/io/cryostat/core/agent/LocalProbeTemplateService.java
+++ b/src/main/java/io/cryostat/core/agent/LocalProbeTemplateService.java
@@ -91,6 +91,7 @@ public class LocalProbeTemplateService implements ProbeTemplateService {
             throws FileAlreadyExistsException, IOException, SAXException {
         try (inputStream) {
             ProbeTemplate template = new ProbeTemplate();
+            template.setFileName(filename);
             // If validation fails this will throw a ProbeValidationException with details
             template.deserialize(inputStream);
             Path path = fs.pathOf(env.getEnv(TEMPLATE_PATH), filename);
@@ -108,9 +109,10 @@ public class LocalProbeTemplateService implements ProbeTemplateService {
         }
     }
 
-    public String getTemplate(String templateName) throws IOException, SAXException {
+    public String getTemplateContent(String templateName) throws IOException, SAXException {
         Path probeTemplatePath = fs.pathOf(env.getEnv(TEMPLATE_PATH), templateName);
         ProbeTemplate template = new ProbeTemplate();
+        template.setFileName(templateName);
         template.deserialize(fs.newInputStream(probeTemplatePath));
         return template.serialize();
     }

--- a/src/main/java/io/cryostat/core/agent/ProbeTemplate.java
+++ b/src/main/java/io/cryostat/core/agent/ProbeTemplate.java
@@ -107,7 +107,7 @@ public class ProbeTemplate {
         }
 
         Document document = builder.parse(stream);
-        stream.close();
+        stream.trulyClose();
         NodeList elements;
 
         // parse global configurations


### PR DESCRIPTION
Fixes #239 

Changes include:

- `addTemplate` should check if template file exists before validating.
  - Add more contexts in case file-exist error occurs.
  - ProbeTemplate should correctly set its name.
- `addTemplate` should return the `ProbeTemplate` object so that the caller can directly call `serialize` on it.
- Input streams should properly close using the custom `trulyClose`.
- Rename methods to match returned values.