### PR TITLE
feat(svc): add recording start method using event template name and type

### DIFF
--- a/src/main/java/io/cryostat/core/EventOptionsBuilder.java
+++ b/src/main/java/io/cryostat/core/EventOptionsBuilder.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.core;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.common.unit.IConstraint;
+import org.openjdk.jmc.common.unit.IMutableConstrainedMap;
+import org.openjdk.jmc.common.unit.IOptionDescriptor;
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+import org.openjdk.jmc.flightrecorder.configuration.events.IEventTypeID;
+import org.openjdk.jmc.rjmx.IConnectionHandle;
+import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
+import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
+import org.openjdk.jmc.rjmx.services.jfr.internal.FlightRecorderServiceV2;
+
+import io.cryostat.core.net.JFRConnection;
+import io.cryostat.core.tui.ClientWriter;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public class EventOptionsBuilder {
+
+    private final boolean isV2;
+    private final IMutableConstrainedMap<EventOptionID> map;
+    private Map<IEventTypeID, Map<String, IOptionDescriptor<?>>> knownTypes;
+    private Map<String, IEventTypeID> eventIds;
+
+    public EventOptionsBuilder(ClientWriter cw, JFRConnection connection, Supplier<Boolean> v2)
+            throws ServiceNotAvailableException, IOException,
+                    org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException {
+        this.isV2 = v2.get();
+        this.map = connection.getService().getDefaultEventOptions().emptyWithSameConstraints();
+        knownTypes = new HashMap<>();
+        eventIds = new HashMap<>();
+
+        if (!isV2) {
+            cw.println("Flight Recorder V1 is not supported");
+        }
+
+        for (IEventTypeInfo eventTypeInfo : connection.getService().getAvailableEventTypes()) {
+            eventIds.put(
+                    eventTypeInfo.getEventTypeID().getFullKey(), eventTypeInfo.getEventTypeID());
+            knownTypes.putIfAbsent(
+                    eventTypeInfo.getEventTypeID(),
+                    new HashMap<>(eventTypeInfo.getOptionDescriptors()));
+        }
+    }
+
+    public EventOptionsBuilder addEvent(String typeId, String option, String value)
+            throws EventTypeException, EventOptionException, QuantityConversionException {
+        if (!eventIds.containsKey(typeId)) {
+            throw new EventTypeException(typeId);
+        }
+        Map<String, IOptionDescriptor<?>> optionDescriptors = knownTypes.get(eventIds.get(typeId));
+        if (!optionDescriptors.containsKey(option)) {
+            throw new EventOptionException(typeId, option);
+        }
+        IConstraint<?> constraint = optionDescriptors.get(option).getConstraint();
+        Object parsedValue = constraint.parseInteractive(value);
+        constraint.validate(capture(parsedValue));
+        this.map.put(new EventOptionID(eventIds.get(typeId), option), parsedValue);
+
+        return this;
+    }
+
+    static <T, V> V capture(T t) {
+        // TODO clean up this generics hack
+        return (V) t;
+    }
+
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Field is never mutated")
+    public IConstrainedMap<EventOptionID> build() {
+        if (!isV2) {
+            return null;
+        }
+        return map;
+    }
+
+    public static class EventTypeException extends Exception {
+        EventTypeException(String eventType) {
+            super(String.format("Unknown event type \"%s\"", eventType));
+        }
+    }
+
+    public static class EventOptionException extends Exception {
+        EventOptionException(String eventType, String option) {
+            super(String.format("Unknown option \"%s\" for event \"%s\"", option, eventType));
+        }
+    }
+
+    public static class Factory {
+        private final ClientWriter cw;
+
+        public Factory(ClientWriter cw) {
+            this.cw = cw;
+        }
+
+        public EventOptionsBuilder create(JFRConnection connection)
+                throws IOException, ServiceNotAvailableException,
+                        org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException {
+            IConnectionHandle handle = connection.getHandle();
+            return new EventOptionsBuilder(
+                    cw, connection, () -> FlightRecorderServiceV2.isAvailable(handle));
+        }
+    }
+}

--- a/src/main/java/io/cryostat/core/net/CryostatFlightRecorderService.java
+++ b/src/main/java/io/cryostat/core/net/CryostatFlightRecorderService.java
@@ -39,44 +39,26 @@ package io.cryostat.core.net;
 
 import java.io.IOException;
 
-import javax.management.InstanceNotFoundException;
-import javax.management.IntrospectionException;
-import javax.management.ReflectionException;
-import javax.management.remote.JMXServiceURL;
-
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.common.unit.QuantityConversionException;
 import org.openjdk.jmc.rjmx.ConnectionException;
-import org.openjdk.jmc.rjmx.IConnectionHandle;
 import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
+import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
-import io.cryostat.core.sys.Clock;
-import io.cryostat.core.templates.TemplateService;
+import io.cryostat.core.EventOptionsBuilder.EventOptionException;
+import io.cryostat.core.EventOptionsBuilder.EventTypeException;
+import io.cryostat.core.templates.TemplateType;
 
-public interface JFRConnection extends AutoCloseable {
+public interface CryostatFlightRecorderService extends IFlightRecorderService {
 
-    public IConnectionHandle getHandle() throws ConnectionException, IOException;
-
-    public CryostatFlightRecorderService getService()
-            throws ConnectionException, IOException, ServiceNotAvailableException;
-
-    public TemplateService getTemplateService();
-
-    public long getApproximateServerTime(Clock clock);
-
-    public JMXServiceURL getJMXURL() throws IOException;
-
-    public String getHost();
-
-    public int getPort();
-
-    public String getJvmId() throws IDException, IOException;
-
-    public MBeanMetrics getMBeanMetrics()
-            throws ConnectionException, IOException, InstanceNotFoundException,
-                    IntrospectionException, ReflectionException;
-
-    public boolean isConnected();
-
-    public void connect() throws ConnectionException;
-
-    public void disconnect();
+    IRecordingDescriptor start(
+            IConstrainedMap<String> recordingOptions,
+            String templateName,
+            TemplateType preferredTemplateType)
+            throws io.cryostat.core.FlightRecorderException, FlightRecorderException,
+                    ConnectionException, IOException, FlightRecorderException,
+                    ServiceNotAvailableException, QuantityConversionException, EventOptionException,
+                    EventTypeException;
 }

--- a/src/main/java/io/cryostat/core/net/CryostatFlightRecorderService.java
+++ b/src/main/java/io/cryostat/core/net/CryostatFlightRecorderService.java
@@ -38,9 +38,13 @@
 package io.cryostat.core.net;
 
 import java.io.IOException;
+import java.text.ParseException;
 
 import org.openjdk.jmc.common.unit.IConstrainedMap;
 import org.openjdk.jmc.common.unit.QuantityConversionException;
+import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+import org.openjdk.jmc.flightrecorder.controlpanel.ui.configuration.model.xml.XMLModel;
+import org.openjdk.jmc.flightrecorder.controlpanel.ui.model.EventConfiguration;
 import org.openjdk.jmc.rjmx.ConnectionException;
 import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
 import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
@@ -49,7 +53,10 @@ import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
 
 import io.cryostat.core.EventOptionsBuilder.EventOptionException;
 import io.cryostat.core.EventOptionsBuilder.EventTypeException;
+import io.cryostat.core.templates.Template;
 import io.cryostat.core.templates.TemplateType;
+
+import org.jsoup.nodes.Document;
 
 public interface CryostatFlightRecorderService extends IFlightRecorderService {
 
@@ -61,4 +68,22 @@ public interface CryostatFlightRecorderService extends IFlightRecorderService {
                     ConnectionException, IOException, FlightRecorderException,
                     ServiceNotAvailableException, QuantityConversionException, EventOptionException,
                     EventTypeException;
+
+    default IRecordingDescriptor start(
+            IConstrainedMap<String> recordingOptions, Template eventTemplate)
+            throws io.cryostat.core.FlightRecorderException, FlightRecorderException,
+                    ConnectionException, IOException, FlightRecorderException,
+                    ServiceNotAvailableException, QuantityConversionException, EventOptionException,
+                    EventTypeException {
+        return start(recordingOptions, eventTemplate.getName(), eventTemplate.getType());
+    }
+
+    default IRecordingDescriptor start(IConstrainedMap<String> recordingOptions, Document template)
+            throws FlightRecorderException, ParseException, IOException {
+        XMLModel model = EventConfiguration.createModel(template.toString());
+        IConstrainedMap<EventOptionID> eventOptions =
+                new EventConfiguration(model)
+                        .getEventOptions(getDefaultEventOptions().emptyWithSameConstraints());
+        return start(recordingOptions, eventOptions);
+    }
 }

--- a/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
+++ b/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
@@ -70,7 +70,6 @@ import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
 import org.openjdk.jmc.rjmx.internal.DefaultConnectionHandle;
 import org.openjdk.jmc.rjmx.internal.RJMXConnection;
 import org.openjdk.jmc.rjmx.internal.ServerDescriptor;
-import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 import org.openjdk.jmc.rjmx.services.jfr.internal.FlightRecorderServiceFactory;
 import org.openjdk.jmc.rjmx.services.jfr.internal.FlightRecorderServiceV2;
 import org.openjdk.jmc.rjmx.subscription.MRI;
@@ -132,19 +131,9 @@ public class JFRJMXConnection implements JFRConnection {
         return handle;
     }
 
-    public synchronized IFlightRecorderService getService()
+    public synchronized CryostatFlightRecorderService getService()
             throws ConnectionException, IOException, ServiceNotAvailableException {
-        if (!isConnected()) {
-            connect();
-        }
-        IFlightRecorderService service = serviceFactory.getServiceInstance(getHandle());
-        if (service == null || !isConnected()) {
-            throw new ConnectionException(
-                    String.format(
-                            "Could not connect to remote target %s",
-                            this.connectionDescriptor.createJMXServiceURL().toString()));
-        }
-        return service;
+        return new JmxFlightRecorderService(this, cw);
     }
 
     public TemplateService getTemplateService() {

--- a/src/main/java/io/cryostat/core/net/JmxFlightRecorderService.java
+++ b/src/main/java/io/cryostat/core/net/JmxFlightRecorderService.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.core.net;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.openjdk.jmc.common.unit.IConstrainedMap;
+import org.openjdk.jmc.common.unit.IDescribedMap;
+import org.openjdk.jmc.common.unit.IOptionDescriptor;
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
+import org.openjdk.jmc.flightrecorder.configuration.events.IEventTypeID;
+import org.openjdk.jmc.rjmx.ConnectionException;
+import org.openjdk.jmc.rjmx.IConnectionHandle;
+import org.openjdk.jmc.rjmx.ServiceNotAvailableException;
+import org.openjdk.jmc.rjmx.services.jfr.FlightRecorderException;
+import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
+import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+import org.openjdk.jmc.rjmx.services.jfr.internal.FlightRecorderServiceFactory;
+import org.openjdk.jmc.rjmx.services.jfr.internal.FlightRecorderServiceV2;
+
+import io.cryostat.core.EventOptionsBuilder;
+import io.cryostat.core.EventOptionsBuilder.EventOptionException;
+import io.cryostat.core.EventOptionsBuilder.EventTypeException;
+import io.cryostat.core.templates.Template;
+import io.cryostat.core.templates.TemplateType;
+import io.cryostat.core.tui.ClientWriter;
+
+public class JmxFlightRecorderService implements CryostatFlightRecorderService {
+
+    private final JFRJMXConnection conn;
+    private final IFlightRecorderService delegate;
+    private final ClientWriter cw;
+
+    JmxFlightRecorderService(JFRJMXConnection conn, ClientWriter cw)
+            throws ConnectionException, ServiceNotAvailableException, IOException {
+        this.conn = conn;
+        if (!conn.isConnected()) {
+            conn.connect();
+        }
+        IFlightRecorderService service =
+                new FlightRecorderServiceFactory().getServiceInstance(conn.getHandle());
+        if (service == null || !conn.isConnected()) {
+            throw new ConnectionException(
+                    String.format(
+                            "Could not connect to remote target %s",
+                            conn.connectionDescriptor.createJMXServiceURL().toString()));
+        }
+        this.delegate = service;
+        this.cw = cw;
+    }
+
+    @Override
+    public List<IRecordingDescriptor> getAvailableRecordings() throws FlightRecorderException {
+        return delegate.getAvailableRecordings();
+    }
+
+    @Override
+    public IRecordingDescriptor getSnapshotRecording() throws FlightRecorderException {
+        return delegate.getSnapshotRecording();
+    }
+
+    @Override
+    public IRecordingDescriptor getUpdatedRecordingDescription(IRecordingDescriptor descriptor)
+            throws FlightRecorderException {
+        return delegate.getUpdatedRecordingDescription(descriptor);
+    }
+
+    @Override
+    public IRecordingDescriptor start(
+            IConstrainedMap<String> recordingOptions, IConstrainedMap<EventOptionID> eventOptions)
+            throws FlightRecorderException {
+        return delegate.start(recordingOptions, eventOptions);
+    }
+
+    @Override
+    public void stop(IRecordingDescriptor descriptor) throws FlightRecorderException {
+        delegate.stop(descriptor);
+    }
+
+    @Override
+    public void close(IRecordingDescriptor descriptor) throws FlightRecorderException {
+        delegate.close(descriptor);
+    }
+
+    @Override
+    public Map<String, IOptionDescriptor<?>> getAvailableRecordingOptions()
+            throws FlightRecorderException {
+        return delegate.getAvailableRecordingOptions();
+    }
+
+    @Override
+    public IConstrainedMap<String> getRecordingOptions(IRecordingDescriptor recording)
+            throws FlightRecorderException {
+        return delegate.getRecordingOptions(recording);
+    }
+
+    @Override
+    public Collection<? extends IEventTypeInfo> getAvailableEventTypes()
+            throws FlightRecorderException {
+        return delegate.getAvailableEventTypes();
+    }
+
+    @Override
+    public Map<? extends IEventTypeID, ? extends IEventTypeInfo> getEventTypeInfoMapByID()
+            throws FlightRecorderException {
+        return delegate.getEventTypeInfoMapByID();
+    }
+
+    @Override
+    public IConstrainedMap<EventOptionID> getCurrentEventTypeSettings()
+            throws FlightRecorderException {
+        return delegate.getCurrentEventTypeSettings();
+    }
+
+    @Override
+    public IConstrainedMap<EventOptionID> getEventSettings(IRecordingDescriptor recording)
+            throws FlightRecorderException {
+        return delegate.getEventSettings(recording);
+    }
+
+    @Override
+    public InputStream openStream(IRecordingDescriptor descriptor, boolean removeOnClose)
+            throws FlightRecorderException {
+        return delegate.openStream(descriptor, removeOnClose);
+    }
+
+    @Override
+    public InputStream openStream(
+            IRecordingDescriptor descriptor,
+            IQuantity startTime,
+            IQuantity endTime,
+            boolean removeOnClose)
+            throws FlightRecorderException {
+        return delegate.openStream(descriptor, startTime, endTime, removeOnClose);
+    }
+
+    @Override
+    public InputStream openStream(
+            IRecordingDescriptor descriptor, IQuantity lastPartDuration, boolean removeOnClose)
+            throws FlightRecorderException {
+        return delegate.openStream(descriptor, lastPartDuration, removeOnClose);
+    }
+
+    @Override
+    public List<String> getServerTemplates() throws FlightRecorderException {
+        return delegate.getServerTemplates();
+    }
+
+    @Override
+    public void updateEventOptions(
+            IRecordingDescriptor descriptor, IConstrainedMap<EventOptionID> options)
+            throws FlightRecorderException {
+        delegate.updateEventOptions(descriptor, options);
+    }
+
+    @Override
+    public void updateRecordingOptions(
+            IRecordingDescriptor descriptor, IConstrainedMap<String> options)
+            throws FlightRecorderException {
+        delegate.updateRecordingOptions(descriptor, options);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return delegate.isEnabled();
+    }
+
+    @Override
+    public void enable() throws FlightRecorderException {
+        delegate.enable();
+    }
+
+    @Override
+    public String getVersion() {
+        return delegate.getVersion();
+    }
+
+    @Override
+    public IDescribedMap<String> getDefaultRecordingOptions() {
+        return delegate.getDefaultRecordingOptions();
+    }
+
+    @Override
+    public IDescribedMap<EventOptionID> getDefaultEventOptions() {
+        return delegate.getDefaultEventOptions();
+    }
+
+    @Override
+    public IRecordingDescriptor start(
+            IConstrainedMap<String> recordingOptions,
+            String templateName,
+            TemplateType preferredTemplateType)
+            throws io.cryostat.core.FlightRecorderException, FlightRecorderException,
+                    ConnectionException, IOException, FlightRecorderException,
+                    ServiceNotAvailableException, QuantityConversionException, EventOptionException,
+                    EventTypeException {
+        return delegate.start(recordingOptions, enableEvents(templateName, preferredTemplateType));
+    }
+
+    private IConstrainedMap<EventOptionID> enableEvents(
+            String templateName, TemplateType templateType)
+            throws ConnectionException, IOException, io.cryostat.core.FlightRecorderException,
+                    FlightRecorderException, ServiceNotAvailableException,
+                    QuantityConversionException, EventOptionException, EventTypeException {
+        if (templateName.equals("ALL")) {
+            return enableAllEvents();
+        }
+        // if template type not specified, try to find a Custom template by that name. If none,
+        // fall back on finding a Target built-in template by the name. If not, throw an
+        // exception and bail out.
+        TemplateType type = getPreferredTemplateType(conn, templateName, templateType);
+        return conn.getTemplateService().getEvents(templateName, type).get();
+    }
+
+    private IConstrainedMap<EventOptionID> enableAllEvents()
+            throws ConnectionException, IOException, FlightRecorderException,
+                    ServiceNotAvailableException, QuantityConversionException, EventOptionException,
+                    EventTypeException {
+
+        IConnectionHandle handle = conn.getHandle();
+        EventOptionsBuilder builder =
+                new EventOptionsBuilder(
+                        cw, conn, () -> FlightRecorderServiceV2.isAvailable(handle));
+
+        for (IEventTypeInfo eventTypeInfo : conn.getService().getAvailableEventTypes()) {
+            builder.addEvent(eventTypeInfo.getEventTypeID().getFullKey(), "enabled", "true");
+        }
+
+        return builder.build();
+    }
+
+    private TemplateType getPreferredTemplateType(
+            JFRConnection connection, String templateName, TemplateType templateType)
+            throws io.cryostat.core.FlightRecorderException {
+        if (templateType != null) {
+            return templateType;
+        }
+        if (templateName.equals("ALL")) {
+            // special case for the ALL meta-template
+            return TemplateType.TARGET;
+        }
+        List<Template> matchingNameTemplates =
+                connection.getTemplateService().getTemplates().stream()
+                        .filter(t -> t.getName().equals(templateName))
+                        .collect(Collectors.toList());
+        boolean custom =
+                matchingNameTemplates.stream()
+                        .anyMatch(t -> t.getType().equals(TemplateType.CUSTOM));
+        if (custom) {
+            return TemplateType.CUSTOM;
+        }
+        boolean target =
+                matchingNameTemplates.stream()
+                        .anyMatch(t -> t.getType().equals(TemplateType.TARGET));
+        if (target) {
+            return TemplateType.TARGET;
+        }
+        throw new IllegalArgumentException(
+                String.format("Invalid/unknown event template %s", templateName));
+    }
+}

--- a/src/main/java/io/cryostat/core/net/JmxFlightRecorderService.java
+++ b/src/main/java/io/cryostat/core/net/JmxFlightRecorderService.java
@@ -278,10 +278,6 @@ public class JmxFlightRecorderService implements CryostatFlightRecorderService {
         if (templateType != null) {
             return templateType;
         }
-        if (templateName.equals("ALL")) {
-            // special case for the ALL meta-template
-            return TemplateType.TARGET;
-        }
         List<Template> matchingNameTemplates =
                 connection.getTemplateService().getTemplates().stream()
                         .filter(t -> t.getName().equals(templateName))

--- a/src/main/java/io/cryostat/core/serialization/SerializableEventTypeInfo.java
+++ b/src/main/java/io/cryostat/core/serialization/SerializableEventTypeInfo.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.core.serialization;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openjdk.jmc.common.unit.IOptionDescriptor;
+import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class SerializableEventTypeInfo {
+
+    private String name;
+    private String typeId;
+    private String description;
+    private String[] category;
+    private Map<String, SerializableOptionDescriptor> options;
+
+    public SerializableEventTypeInfo(IEventTypeInfo orig) {
+        this.name = orig.getName();
+        this.typeId = orig.getEventTypeID().getFullKey();
+        this.description = orig.getDescription();
+        this.category = orig.getHierarchicalCategory();
+
+        Map<String, ? extends IOptionDescriptor<?>> origOptions = orig.getOptionDescriptors();
+        this.options = new HashMap<>(origOptions.size());
+        for (Map.Entry<String, ? extends IOptionDescriptor<?>> entry : origOptions.entrySet()) {
+            this.options.put(entry.getKey(), new SerializableOptionDescriptor(entry.getValue()));
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTypeId() {
+        return this.typeId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String[] getHierarchicalCategory() {
+        return Arrays.copyOf(category, category.length);
+    }
+
+    public Map<String, SerializableOptionDescriptor> getOptionDescriptors() {
+        return new HashMap<String, SerializableOptionDescriptor>(options);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+}

--- a/src/main/java/io/cryostat/core/serialization/SerializableOptionDescriptor.java
+++ b/src/main/java/io/cryostat/core/serialization/SerializableOptionDescriptor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.core.serialization;
+
+import org.openjdk.jmc.common.unit.IOptionDescriptor;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class SerializableOptionDescriptor {
+
+    private String name;
+    private String description;
+    private String defaultValue;
+
+    public SerializableOptionDescriptor(IOptionDescriptor<?> orig) {
+        this.name = orig.getName();
+        this.description = orig.getDescription();
+        this.defaultValue = orig.getDefault().toString();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+}

--- a/src/main/java/io/cryostat/core/serialization/SerializableRecordingDescriptor.java
+++ b/src/main/java/io/cryostat/core/serialization/SerializableRecordingDescriptor.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.core.serialization;
+
+import java.util.Map;
+
+import javax.management.ObjectName;
+
+import org.openjdk.jmc.common.unit.IQuantity;
+import org.openjdk.jmc.common.unit.QuantityConversionException;
+import org.openjdk.jmc.common.unit.UnitLookup;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor;
+import org.openjdk.jmc.rjmx.services.jfr.IRecordingDescriptor.RecordingState;
+
+import jdk.jfr.Recording;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class SerializableRecordingDescriptor {
+
+    protected long id;
+    protected String name;
+    protected RecordingState state;
+    protected long startTime;
+    protected long duration;
+    protected boolean continuous;
+    protected boolean toDisk;
+    protected long maxSize;
+    protected long maxAge;
+
+    public SerializableRecordingDescriptor(
+            long id,
+            String name,
+            RecordingState state,
+            long startTime,
+            long duration,
+            boolean continuous,
+            boolean toDisk,
+            long maxSize,
+            long maxAge) {
+        this.id = id;
+        this.name = name;
+        this.state = state;
+        this.startTime = startTime;
+        this.duration = duration;
+        this.continuous = continuous;
+        this.toDisk = toDisk;
+        this.maxSize = maxSize;
+        this.maxAge = maxAge;
+    }
+
+    public SerializableRecordingDescriptor(Recording recording) {
+        this(
+                recording.getId(),
+                recording.getName(),
+                RecordingState.valueOf(recording.getState().name()),
+                recording.getStartTime() == null ? 0 : recording.getStartTime().toEpochMilli(),
+                recording.getDuration() == null ? 0 : recording.getDuration().toMillis(),
+                recording.getDuration() == null,
+                recording.isToDisk(),
+                recording.getMaxSize(),
+                recording.getMaxAge() == null ? 0 : recording.getMaxAge().toMillis());
+    }
+
+    public SerializableRecordingDescriptor(IRecordingDescriptor orig)
+            throws QuantityConversionException {
+        this.id = orig.getId();
+        this.name = orig.getName();
+        this.state = orig.getState();
+        this.startTime = orig.getStartTime().longValueIn(UnitLookup.EPOCH_MS);
+        this.duration = orig.getDuration().longValueIn(UnitLookup.MILLISECOND);
+        this.continuous = orig.isContinuous();
+        this.toDisk = orig.getToDisk();
+        this.maxSize = orig.getMaxSize().longValueIn(UnitLookup.BYTE);
+        this.maxAge = orig.getMaxAge().longValueIn(UnitLookup.MILLISECOND);
+    }
+
+    public SerializableRecordingDescriptor(SerializableRecordingDescriptor o) {
+        this.id = o.getId();
+        this.name = o.getName();
+        this.state = o.getState();
+        this.startTime = o.getStartTime();
+        this.duration = o.getDuration();
+        this.continuous = o.isContinuous();
+        this.toDisk = o.getToDisk();
+        this.maxSize = o.getMaxSize();
+        this.maxAge = o.getMaxAge();
+    }
+
+    public IRecordingDescriptor toJmcForm() {
+        return new IRecordingDescriptor() {
+
+            @Override
+            public Long getId() {
+                return id;
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public RecordingState getState() {
+                return state;
+            }
+
+            @Override
+            public Map<String, ?> getOptions() {
+                return Map.of();
+            }
+
+            @Override
+            public ObjectName getObjectName() {
+                return null;
+            }
+
+            @Override
+            public IQuantity getDataStartTime() {
+                return getStartTime();
+            }
+
+            @Override
+            public IQuantity getDataEndTime() {
+                return getStartTime().add(getDuration());
+            }
+
+            @Override
+            public IQuantity getStartTime() {
+                return UnitLookup.EPOCH_MS.quantity(startTime);
+            }
+
+            @Override
+            public IQuantity getDuration() {
+                return UnitLookup.MILLISECOND.quantity(duration);
+            }
+
+            @Override
+            public boolean isContinuous() {
+                return continuous;
+            }
+
+            @Override
+            public boolean getToDisk() {
+                return toDisk;
+            }
+
+            @Override
+            public IQuantity getMaxSize() {
+                return UnitLookup.BYTE.quantity(maxSize);
+            }
+
+            @Override
+            public IQuantity getMaxAge() {
+                return UnitLookup.MILLISECOND.quantity(maxAge);
+            }
+        };
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public RecordingState getState() {
+        return state;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public boolean isContinuous() {
+        return continuous;
+    }
+
+    public boolean getToDisk() {
+        return toDisk;
+    }
+
+    public long getMaxSize() {
+        return maxSize;
+    }
+
+    public long getMaxAge() {
+        return maxAge;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+}

--- a/src/main/java/io/cryostat/core/templates/RemoteTemplateService.java
+++ b/src/main/java/io/cryostat/core/templates/RemoteTemplateService.java
@@ -61,7 +61,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.parser.Parser;
 import org.jsoup.select.Elements;
 
-public class RemoteTemplateService extends AbstractTemplateService implements TemplateService {
+public class RemoteTemplateService extends AbstractTemplateService {
 
     private final JFRConnection conn;
 

--- a/src/test/java/io/cryostat/core/EventOptionsCustomizerTest.java
+++ b/src/test/java/io/cryostat/core/EventOptionsCustomizerTest.java
@@ -47,11 +47,11 @@ import org.openjdk.jmc.common.unit.IOptionDescriptor;
 import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 import org.openjdk.jmc.flightrecorder.configuration.events.IEventTypeID;
 import org.openjdk.jmc.rjmx.services.jfr.IEventTypeInfo;
-import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
 import io.cryostat.core.EventOptionsCustomizer.EventOptionException;
 import io.cryostat.core.EventOptionsCustomizer.EventTypeException;
 import io.cryostat.core.EventOptionsCustomizer.OptionValueException;
+import io.cryostat.core.net.CryostatFlightRecorderService;
 import io.cryostat.core.net.JFRConnection;
 
 import org.hamcrest.MatcherAssert;
@@ -69,7 +69,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class EventOptionsCustomizerTest {
 
     @Mock JFRConnection connection;
-    @Mock IFlightRecorderService service;
+    @Mock CryostatFlightRecorderService service;
     @Mock IDescribedMap<EventOptionID> defaultMap;
     @Mock IMutableConstrainedMap<EventOptionID> emptyMap;
     EventOptionsCustomizer customizer;

--- a/src/test/java/io/cryostat/core/templates/RemoteTemplateServiceTest.java
+++ b/src/test/java/io/cryostat/core/templates/RemoteTemplateServiceTest.java
@@ -43,8 +43,8 @@ import java.util.Optional;
 import org.openjdk.jmc.flightrecorder.configuration.internal.DefaultValueMap;
 import org.openjdk.jmc.flightrecorder.configuration.internal.EventOptionDescriptorMapper;
 import org.openjdk.jmc.flightrecorder.configuration.internal.EventTypeIDV2;
-import org.openjdk.jmc.rjmx.services.jfr.IFlightRecorderService;
 
+import io.cryostat.core.net.CryostatFlightRecorderService;
 import io.cryostat.core.net.JFRConnection;
 
 import org.apache.commons.io.IOUtils;
@@ -66,7 +66,7 @@ class RemoteTemplateServiceTest {
 
     TemplateService templateSvc;
     @Mock JFRConnection conn;
-    @Mock IFlightRecorderService svc;
+    @Mock CryostatFlightRecorderService svc;
     String xmlText;
 
     @BeforeEach


### PR DESCRIPTION
- chore(svc): extract EventOptionsBuilder from Cryostat application
- chore(svc): add recording start method using event template name and type

Related to https://github.com/cryostatio/cryostat-agent/issues/162
Related to https://github.com/cryostatio/cryostat/issues/1578

This extracts the `EventOptionsBuilder` from the Cryostat application into `-core`, then augments the JMC `IFlightRecorderService` by introducing a subinterface `CryostatFlightRecorderService` that allows for additional/higher-level operations, such as dynamically starting a recording using an event template name+type rather than the JMC `IConstrainedMap`. This will support starting recordings by network request by asking the Agent to simply use a `.jfc` file available to it locally, rather than needing to reserialize the settings defined by that `.jfc` and transmit that over the network, where those settings would be originally retrieved by querying the raw `.jfc` form from the Agent and parsing it to create the `IConstrainedMap` model.

~~A further enhancement to come later will be to allow supplying the entire XML (`.jfc`) `Document` on the recording creation request. The `CryostatFlightRecorderService` implementation will either convert this to the `IConstrainedMap` server-side, or pass it as-is to the Agent for conversion, so that the XML content of Custom event templates does not need to be reserialized between XML, POJO, and possibly JSON in several stages along the flow.~~

Some serialization-related classes are also extracted (and minor refactorings done) from the Cryostat application into -core here, since they will be useful for facilitating (de)serialization of these structures for communication between Cryostat and the Agent.