### PR TITLE
chore(ci): checkout core first to cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,18 @@ jobs:
         sudo apt-get install -y qemu-user-static
     - uses: actions/checkout@v4
       with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: 0
+    - uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - uses: actions/checkout@v4
+      with:
         repository: ${{ github.repository_owner }}/cryostat
         ref: main
         submodules: true
@@ -73,14 +85,6 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-    - uses: actions/cache@v3
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
     - name: maven-settings
       uses: s4u/maven-settings-action@v2
       with:

--- a/.github/workflows/cryostat-test.yml
+++ b/.github/workflows/cryostat-test.yml
@@ -75,6 +75,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: 0
+    - uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - uses: actions/checkout@v4
+      with:
         repository: ${{ github.repository_owner }}/cryostat
         ref: main
         submodules: true
@@ -83,14 +95,6 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-    - uses: actions/cache@v3
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
     - name: maven-settings
       uses: s4u/maven-settings-action@v2
       with:


### PR DESCRIPTION
fixes: #315
Basically, when caching the maven files, the key that we use is unique to each version of the `pom.xml` file. When we checkout the `Cryostat` repo, which has a different `pom.xml` file, we are unable to hit the exact key that we saved the cache under because the hashes of the two different `pom.xml` files are different. Additionally, we are not hitting the cache that was most recently produced for some reason. Therefore, sometimes with changes like the update to `2.26.0-SNAPSHOT`, we are actually restoring an older version of -core that hasn't been updated yet.
Here, the change I've made just checks out the -core PR branch before checking out the main `Cryostat` branch so the right files are cached into the `~/.m2` folder. 