### PR TITLE
fix(reports): split rule evaluations across executor submissions

### DIFF
--- a/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
+++ b/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
@@ -55,29 +55,16 @@ import org.openjdk.jmc.flightrecorder.rules.Severity;
 import org.openjdk.jmc.flightrecorder.rules.TypedResult;
 import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.input.CountingInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Re-implementation of {@link ReportGenerator} where the report generation task is represented by a
- * {@link Future}, allowing callers to cancel ongoing rules report analyses or to easily time out on
- * analysis requests. This should eventually replace {@link ReportGenerator} entirely - there should
- * only be benefits to using this implementation.
- */
-@SuppressFBWarnings(
-        value = "THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION",
-        justification = "There are no basic exceptions being thrown")
 public class InterruptibleReportGenerator {
 
     private final ExecutorService qThread = Executors.newCachedThreadPool();
     private final ExecutorService executor;
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    @SuppressFBWarnings(
-            value = "EI_EXPOSE_REP2",
-            justification = "fields are not exposed since there are no getters")
     public InterruptibleReportGenerator(ExecutorService executor) {
         this.executor = executor;
     }

--- a/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
+++ b/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
@@ -201,8 +201,10 @@ public class InterruptibleReportGenerator {
                     }
                 }
             }
-            RuleEvaluator re = new RuleEvaluator(futureQueue);
-            executor.submit(re);
+            RunnableFuture<IResult> resultFuture;
+            while ((resultFuture = futureQueue.poll()) != null) {
+                executor.submit(resultFuture);
+            }
             Collection<IResult> results = new HashSet<IResult>();
             for (Future<IResult> future : resultFutures.values()) {
                 results.add(future.get());
@@ -345,21 +347,5 @@ public class InterruptibleReportGenerator {
             }
         }
         return true;
-    }
-
-    private static class RuleEvaluator implements Runnable {
-        private Queue<RunnableFuture<IResult>> futureQueue;
-
-        public RuleEvaluator(Queue<RunnableFuture<IResult>> futureQueue) {
-            this.futureQueue = futureQueue;
-        }
-
-        @Override
-        public void run() {
-            RunnableFuture<IResult> resultFuture;
-            while ((resultFuture = futureQueue.poll()) != null) {
-                resultFuture.run();
-            }
-        }
     }
 }


### PR DESCRIPTION
`RuleEvaluator` causes the whole queue of futures to be evaluated by whoever calls `evaluator.run()` - in this case, one thread from the Executor. If there are many threads available via that Executor then we don't take any advantage of the parallelism possible in analysis rules this way. With this PR this `RuleEvaluator` is removed and each rule in the queue to be processed is immediately submitted to the executor pool, then the final results are all collected by the `qThread` and returned. This way a multithreaded executor provides more parallelism within individual rule analyses, rather than only helping to parallelize multiple analyses - ie parallelism within a single file analysis instead of only at the per-file level.