### PR TITLE
ci(central): remove workflow version update automation

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -3,20 +3,14 @@ name: Publish a new Maven Central release
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release version'
-        required: true
-      nextVersion:
-        description: 'Next version after release (-SNAPSHOT will be added automatically)'
-        required: true
+    # inputs:
+    #   version:
+    #     description: 'Release version'
+    #     required: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: write
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -30,21 +24,8 @@ jobs:
           cache: maven
       - name: Run a build of the code base before release
         run: ./mvnw --batch-mode --no-transfer-progress clean install
-      - name: Set release version
-        run: ./mvnw --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.version }}
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-      - name: Commit & Push changes
-        uses: actions-js/push@v1.4
-        with:
-          github_token: ${{ secrets.SUBMODULE_TOKEN }}
-          message: "Releasing version ${{ github.event.inputs.version }}"
+      # - name: Set release version
+      #   run: ./mvnw --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.version }}
       - name: Release with JReleaser
         env:
           JRELEASER_TAG_NAME: ${{ github.event.inputs.version }}
@@ -55,11 +36,3 @@ jobs:
           JRELEASER_NEXUS2_PASSWORD: ${{ secrets.MAVEN_CENTRAL_NEXUS2_PASSWORD }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.SUBMODULE_TOKEN }}
         run: ./release.sh
-      - name: Set the next release version
-        run: ./mvnw --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.nextVersion }}-SNAPSHOT
-      - name: Commit & Push changes
-        uses: actions-js/push@v1.4
-        with:
-          github_token: ${{ secrets.SUBMODULE_TOKEN }}
-          message: "Setting version ${{ github.event.inputs.nextVersion }}-SNAPSHOT"
-

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -22,13 +22,13 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Build with Maven
-      run: mvn -B -U package --file pom.xml
+      run: ./mvnw -B -U package --file pom.xml
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      run: ./mvnw deploy -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}
     - uses: skjolber/maven-cache-github-action@v1


### PR DESCRIPTION
Related to #92
Related to #338

Removes the version updating automation from the workflow since this is not working with the branch protection rules we have set for `main` and the `github-actions[bot]` pseudo-user, nor the PAT that we use for other similar updates with web-client submodules.

For now this is left as a manual step that publishes the current (probably `-SNAPSHOT`) version from `main` directly to central. Once that's working I'll follow up with another PR to merge that workflow into the [pre-existing one](https://github.com/cryostatio/cryostat-core/blob/main/.github/workflows/maven-publish.yml) that builds and publishes to the GitHub Maven Packages repository, so that this new action for publishing to Maven Central is just an automatic addition to our existing release workflow process.