### PR TITLE
chore(maven): change URL for Maven Central publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,8 +339,8 @@
                   <nexus2>
                     <maven-central>
                       <active>ALWAYS</active>
-                      <url>https://oss.sonatype.org/service/local</url>
-                      <snapshotUrl>https://oss.sonatype.org/content/repositories/snapshots/</snapshotUrl>
+                      <url>https://s01.oss.sonatype.org/service/local</url>
+                      <snapshotUrl>https://s01.oss.sonatype.org/content/repositories/snapshots/</snapshotUrl>
                       <closeRepository>true</closeRepository>
                       <releaseRepository>true</releaseRepository>
                       <stagingRepositories>target/staging-deploy</stagingRepositories>


### PR DESCRIPTION
Our group ID is set up to publish to the newer s01 host: https://central.sonatype.org/publish/publish-maven/#deployment

Related to: #92 