### PR TITLE
fix(CI): checkout -core to cache mvn files before building Cryostat3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,11 @@ jobs:
         pull-requests: write
         statuses: write
     steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: 0
     - uses: actions/cache@v3
       with:
         path: ~/.m2


### PR DESCRIPTION
fixes: #349 