### PR TITLE
chore(logger): do not pass logger instances into constructors

### DIFF
--- a/src/main/java/io/cryostat/core/net/discovery/JvmDiscoveryClient.java
+++ b/src/main/java/io/cryostat/core/net/discovery/JvmDiscoveryClient.java
@@ -27,18 +27,18 @@ import org.openjdk.jmc.jdp.client.DiscoveryListener;
 import org.openjdk.jmc.jdp.client.JDPClient;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JvmDiscoveryClient {
 
-    private final Logger logger;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final JDPClient jdp;
     private final Set<Consumer<JvmDiscoveryEvent>> eventListeners;
     private final DiscoveryListener listener;
 
     // package-private for testing
-    JvmDiscoveryClient(JDPClient jdp, Logger logger) {
+    JvmDiscoveryClient(JDPClient jdp) {
         this.jdp = jdp;
-        this.logger = logger;
         this.eventListeners = new HashSet<>();
         this.listener =
                 new DiscoveryListener() {
@@ -74,8 +74,8 @@ public class JvmDiscoveryClient {
                 };
     }
 
-    public JvmDiscoveryClient(Logger logger) {
-        this(new JDPClient(), logger);
+    public JvmDiscoveryClient() {
+        this(new JDPClient());
     }
 
     public void start() throws IOException {

--- a/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
+++ b/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
@@ -58,6 +58,7 @@ import org.openjdk.jmc.flightrecorder.rules.util.RulesToolkit;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.input.CountingInputStream;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Re-implementation of {@link ReportGenerator} where the report generation task is represented by a
@@ -72,14 +73,13 @@ public class InterruptibleReportGenerator {
 
     private final ExecutorService qThread = Executors.newCachedThreadPool();
     private final ExecutorService executor;
-    private final Logger logger;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @SuppressFBWarnings(
             value = "EI_EXPOSE_REP2",
             justification = "fields are not exposed since there are no getters")
-    public InterruptibleReportGenerator(ExecutorService executor, Logger logger) {
+    public InterruptibleReportGenerator(ExecutorService executor) {
         this.executor = executor;
-        this.logger = logger;
     }
 
     public Future<Map<String, AnalysisResult>> generateEvalMapInterruptibly(

--- a/src/test/java/io/cryostat/core/net/discovery/JvmDiscoveryClientTest.java
+++ b/src/test/java/io/cryostat/core/net/discovery/JvmDiscoveryClientTest.java
@@ -41,19 +41,16 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class JvmDiscoveryClientTest {
 
     JvmDiscoveryClient client;
     @Mock JDPClient jdp;
-    @Mock Logger logger = LoggerFactory.getLogger(getClass());
 
     @BeforeEach
     void setup() {
-        this.client = new JvmDiscoveryClient(jdp, logger);
+        this.client = new JvmDiscoveryClient(jdp);
     }
 
     @Test

--- a/src/test/java/io/cryostat/core/reports/InterruptibleReportGeneratorTest.java
+++ b/src/test/java/io/cryostat/core/reports/InterruptibleReportGeneratorTest.java
@@ -34,20 +34,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(MockitoExtension.class)
 class InterruptibleReportGeneratorTest {
 
     @Mock InputStream recording;
-    @Mock Logger logger = LoggerFactory.getLogger(getClass());
 
     InterruptibleReportGenerator generator;
 
     @BeforeEach()
     void setup() throws Exception {
-        generator = new InterruptibleReportGenerator(Executors.newWorkStealingPool(1), logger);
+        generator = new InterruptibleReportGenerator(Executors.newWorkStealingPool(1));
     }
 
     @Test


### PR DESCRIPTION
Related to #348

No need to pass in logger instances anymore, they can and should just use the LoggerFactory to get an instance for themselves.
