### PR TITLE
chore(build): include jandex plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
   <maven.compiler.source>${java.version}</maven.compiler.source>
   <jmc.version>8.2.0</jmc.version>
 
+  <io.smallrye.jandex.plugin.version>3.1.6</io.smallrye.jandex.plugin.version>
   <org.apache.maven.plugins.compiler.version>3.12.1</org.apache.maven.plugins.compiler.version>
   <org.apache.maven.plugins.surefire.version>3.2.5</org.apache.maven.plugins.surefire.version>
   <org.apache.maven.plugins.site.version>3.12.1</org.apache.maven.plugins.site.version>
@@ -194,6 +195,19 @@
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-compiler-plugin</artifactId>
       <version>${org.apache.maven.plugins.compiler.version}</version>
+    </plugin>
+    <plugin>
+      <groupId>io.smallrye</groupId>
+      <artifactId>jandex-maven-plugin</artifactId>
+      <version>${io.smallrye.jandex.plugin.version}</version>
+      <executions>
+        <execution>
+          <id>make-index</id>
+          <goals>
+            <goal>jandex</goal>
+          </goals>
+        </execution>
+      </executions>
     </plugin>
     <plugin>
       <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #355

Useful for Quarkus in Cryostat 3.
