### PR TITLE
chore(mbeans): use own-defined type to replace java.lang.management.MemoryUsage

### DIFF
--- a/src/main/java/io/cryostat/core/net/MemoryMetrics.java
+++ b/src/main/java/io/cryostat/core/net/MemoryMetrics.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class MemoryMetrics {
-    private final MemoryUsage heapMemoryUsage;
-    private final MemoryUsage nonHeapMemoryUsage;
+    private final MemoryUtilization heapMemoryUsage;
+    private final MemoryUtilization nonHeapMemoryUsage;
     private final long objectPendingFinalizationCount;
     private final long freeHeapMemory;
     private final long freeNonHeapMemory;
@@ -31,12 +31,15 @@ public class MemoryMetrics {
 
     public MemoryMetrics(Map<String, Object> attributes) {
         this.heapMemoryUsage =
-                (MemoryUsage)
-                        attributes.getOrDefault("HeapMemoryUsage", new MemoryUsage(-1, 0, 0, -1));
+                MemoryUtilization.from(
+                        (MemoryUsage)
+                                attributes.getOrDefault(
+                                        "HeapMemoryUsage", new MemoryUsage(-1, 0, 0, -1)));
         this.nonHeapMemoryUsage =
-                (MemoryUsage)
-                        attributes.getOrDefault(
-                                "NonHeapMemoryUsage", new MemoryUsage(-1, 0, 0, -1));
+                MemoryUtilization.from(
+                        (MemoryUsage)
+                                attributes.getOrDefault(
+                                        "NonHeapMemoryUsage", new MemoryUsage(-1, 0, 0, -1)));
         this.objectPendingFinalizationCount =
                 (int) attributes.getOrDefault("ObjectPendingFinalizationCount", Integer.MIN_VALUE);
         this.freeHeapMemory = (long) attributes.getOrDefault("FreeHeapMemory", Long.MIN_VALUE);
@@ -47,11 +50,11 @@ public class MemoryMetrics {
         this.verbose = (boolean) attributes.getOrDefault("Verbose", false);
     }
 
-    public MemoryUsage getHeapMemoryUsage() {
+    public MemoryUtilization getHeapMemoryUsage() {
         return heapMemoryUsage;
     }
 
-    public MemoryUsage getNonHeapMemoryUsage() {
+    public MemoryUtilization getNonHeapMemoryUsage() {
         return nonHeapMemoryUsage;
     }
 

--- a/src/main/java/io/cryostat/core/net/MemoryUtilization.java
+++ b/src/main/java/io/cryostat/core/net/MemoryUtilization.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.core.net;
+
+import java.lang.management.MemoryUsage;
+
+public class MemoryUtilization {
+
+    private final long init;
+    private final long used;
+    private final long committed;
+    private final long max;
+
+    public MemoryUtilization(long init, long used, long committed, long max) {
+        this.init = init;
+        this.used = used;
+        this.committed = committed;
+        this.max = max;
+    }
+
+    public static MemoryUtilization from(MemoryUsage usage) {
+        return new MemoryUtilization(
+                usage.getInit(), usage.getUsed(), usage.getCommitted(), usage.getMax());
+    }
+
+    public long getInit() {
+        return init;
+    }
+
+    public long getUsed() {
+        return used;
+    }
+
+    public long getCommitted() {
+        return committed;
+    }
+
+    public long getMax() {
+        return max;
+    }
+}


### PR DESCRIPTION
Fixes #356
Depends on #357

Workaround related to https://github.com/cryostatio/cryostat3/pull/307 . Quarkus fails to index `java.lang.management.MemoryUsage` and this causes the GraphQL schema validation to fail, since the type is found in the generated schema but is not indexed. Creating this type separately and indexing it with #357 works and is a less leaky abstraction.
