### PR TITLE
fix(jmcagent): widen exception subclass visiblity

### DIFF
--- a/src/main/java/io/cryostat/core/agent/AgentJMXHelper.java
+++ b/src/main/java/io/cryostat/core/agent/AgentJMXHelper.java
@@ -110,13 +110,13 @@ public class AgentJMXHelper {
     @Override
     protected final void finalize() {}
 
-    static class ProbeDefinitionException extends Exception {
+    public static class ProbeDefinitionException extends Exception {
         ProbeDefinitionException(String message, Throwable e) {
             super(message, e);
         }
     }
 
-    static class MBeanRetrieveException extends Exception {
+    public static class MBeanRetrieveException extends Exception {
         MBeanRetrieveException(Throwable e) {
             super(e);
         }


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat3/issues/14

This PR makes the ProbeValidationException and MBeanRetrieveException visible so they can be caught explicitly by consumers (e.g. the Probe handlers in cryostat main).