### PR TITLE
chore(mergify): update rule to backport to jdk11 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,11 +1,11 @@
 pull_request_rules:
-  - name: backport patches to cryostat-v2.4 branch
+  - name: backport patches to jdk11 branch
     conditions:
       - base=main
       - label=backport
     actions:
       backport:
         branches:
-          - cryostat-v2.4
+          - jdk11
         assignees:
           - "{{ author }}"


### PR DESCRIPTION
Since `main` now depends upon JMC 9, which requires JDK 17+, I have created an upstream [`jdk11`](https://github.com/cryostatio/cryostat-core/tree/jdk11) branch which diverges just before the JMC 9 upgrade was merged. This branch will continue to publish `-core` releases in the `2.x` version sequence, and will continue to use JMC 8.x and only require JDK 11+. This is useful for the Cryostat Agent, which depends on `-core` but only very very loosely on the JMC parts, and for which we want JDK 11 compatibility.
