### PR TITLE
chore(cleanup): Abstract away document type

### DIFF
--- a/src/main/java/io/cryostat/core/templates/RemoteTemplateService.java
+++ b/src/main/java/io/cryostat/core/templates/RemoteTemplateService.java
@@ -61,8 +61,7 @@ public class RemoteTemplateService extends AbstractTemplateService {
             return Optional.empty();
         }
         try {
-            Optional<Document> document =
-                    conn.getService().getServerTemplates().stream()
+                    return conn.getService().getServerTemplates().stream()
                             .map(xmlText -> Jsoup.parse(xmlText, "", Parser.xmlParser()))
                             .filter(
                                     doc -> {
@@ -85,12 +84,8 @@ public class RemoteTemplateService extends AbstractTemplateService {
                                         }
                                         return configuration.attr("label").equals(templateName);
                                     })
+                             .map(doc -> document.toString())
                             .findFirst();
-            if (document.isPresent()) {
-                return Optional.of(document.get().toString());
-            } else {
-                return Optional.empty();
-            }
         } catch (org.openjdk.jmc.flightrecorder.configuration.FlightRecorderException
                 | IOException
                 | ServiceNotAvailableException e) {

--- a/src/main/java/io/cryostat/core/templates/RemoteTemplateService.java
+++ b/src/main/java/io/cryostat/core/templates/RemoteTemplateService.java
@@ -33,7 +33,6 @@ import io.cryostat.core.FlightRecorderException;
 import io.cryostat.core.net.JFRConnection;
 
 import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.parser.Parser;
 import org.jsoup.select.Elements;
@@ -61,31 +60,31 @@ public class RemoteTemplateService extends AbstractTemplateService {
             return Optional.empty();
         }
         try {
-                    return conn.getService().getServerTemplates().stream()
-                            .map(xmlText -> Jsoup.parse(xmlText, "", Parser.xmlParser()))
-                            .filter(
-                                    doc -> {
-                                        Elements els = doc.getElementsByTag("configuration");
-                                        if (els.isEmpty()) {
-                                            throw new MalformedXMLException(
-                                                    "Document did not contain \"configuration\""
-                                                            + " element");
-                                        }
-                                        if (els.size() > 1) {
-                                            throw new MalformedXMLException(
-                                                    "Document contains multiple \"configuration\""
-                                                            + " elements");
-                                        }
-                                        Element configuration = els.first();
-                                        if (!configuration.hasAttr("label")) {
-                                            throw new MalformedXMLException(
-                                                    "Configuration element did not have \"label\""
-                                                            + " attribute");
-                                        }
-                                        return configuration.attr("label").equals(templateName);
-                                    })
-                             .map(doc -> document.toString())
-                            .findFirst();
+            return conn.getService().getServerTemplates().stream()
+                    .map(xmlText -> Jsoup.parse(xmlText, "", Parser.xmlParser()))
+                    .filter(
+                            doc -> {
+                                Elements els = doc.getElementsByTag("configuration");
+                                if (els.isEmpty()) {
+                                    throw new MalformedXMLException(
+                                            "Document did not contain \"configuration\""
+                                                    + " element");
+                                }
+                                if (els.size() > 1) {
+                                    throw new MalformedXMLException(
+                                            "Document contains multiple \"configuration\""
+                                                    + " elements");
+                                }
+                                Element configuration = els.first();
+                                if (!configuration.hasAttr("label")) {
+                                    throw new MalformedXMLException(
+                                            "Configuration element did not have \"label\""
+                                                    + " attribute");
+                                }
+                                return configuration.attr("label").equals(templateName);
+                            })
+                    .map(doc -> doc.toString())
+                    .findFirst();
         } catch (org.openjdk.jmc.flightrecorder.configuration.FlightRecorderException
                 | IOException
                 | ServiceNotAvailableException e) {

--- a/src/main/java/io/cryostat/core/templates/TemplateService.java
+++ b/src/main/java/io/cryostat/core/templates/TemplateService.java
@@ -23,18 +23,15 @@ import org.openjdk.jmc.flightrecorder.configuration.events.EventOptionID;
 
 import io.cryostat.core.FlightRecorderException;
 
-import org.jsoup.nodes.Document;
-
 public interface TemplateService {
 
     List<Template> getTemplates() throws FlightRecorderException;
 
-    default Optional<Document> getXml(Template template) throws FlightRecorderException {
+    default Optional<String> getXml(Template template) throws FlightRecorderException {
         return getXml(template.getName(), template.getType());
     }
 
-    Optional<Document> getXml(String templateName, TemplateType type)
-            throws FlightRecorderException;
+    Optional<String> getXml(String templateName, TemplateType type) throws FlightRecorderException;
 
     default Optional<IConstrainedMap<EventOptionID>> getEvents(Template template)
             throws FlightRecorderException {

--- a/src/test/java/io/cryostat/core/templates/RemoteTemplateServiceTest.java
+++ b/src/test/java/io/cryostat/core/templates/RemoteTemplateServiceTest.java
@@ -29,7 +29,6 @@ import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,9 +99,10 @@ class RemoteTemplateServiceTest {
     void getXmlShouldReturnModelFromRemote() throws Exception {
         Mockito.when(conn.getService()).thenReturn(svc);
         Mockito.when(svc.getServerTemplates()).thenReturn(Collections.singletonList(xmlText));
-        Optional<Document> doc = templateSvc.getXml("Profiling", TemplateType.TARGET);
+        Optional<String> doc = templateSvc.getXml("Profiling", TemplateType.TARGET);
         Assertions.assertTrue(doc.isPresent());
-        Assertions.assertTrue(doc.get().hasSameValue(Jsoup.parse(xmlText, "", Parser.xmlParser())));
+        Assertions.assertTrue(
+                doc.get().equals(Jsoup.parse(xmlText, "", Parser.xmlParser()).outerHtml()));
     }
 
     @Test


### PR DESCRIPTION
This PR cleans up the template service to avoid exposing the document type, changing getXML to return the XML string directly as it's used in the S3 template service/api handlers.

Fixes https://github.com/cryostatio/cryostat-core/issues/300