### PR TITLE
ci(maven): run checkout before querying project version

### DIFF
--- a/.github/workflows/push-ci.yml
+++ b/.github/workflows/push-ci.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       project-version: ${{ steps.get-version.outputs.project-version }}
     steps:
+    - uses: actions/checkout@v4
     - id: get-version
       run: |
         PROJECT_VERSION="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"


### PR DESCRIPTION
Related to: #392 