### PR TITLE
build(deps): revert io.smallrye:jandex-maven-plugin from 3.2.0 to 3.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
   <maven.compiler.source>${java.version}</maven.compiler.source>
   <org.openjdk.jmc.version>9.0.0</org.openjdk.jmc.version>
 
-  <io.smallrye.jandex.plugin.version>3.2.0</io.smallrye.jandex.plugin.version>
+  <io.smallrye.jandex.plugin.version>3.1.8</io.smallrye.jandex.plugin.version>
   <org.apache.maven.plugins.compiler.version>3.13.0</org.apache.maven.plugins.compiler.version>
   <org.apache.maven.plugins.surefire.version>3.2.5</org.apache.maven.plugins.surefire.version>
   <org.apache.maven.plugins.site.version>3.12.1</org.apache.maven.plugins.site.version>


### PR DESCRIPTION
Reverts cryostatio/cryostat-core#399

Looks like this causes a build failure:

https://github.com/cryostatio/cryostat3/actions/runs/9129557915/job/25104421866

```
Error:    Run 3: HealthTest.testHealthLiveness » Runtime java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
Error: ]: Build step io.quarkus.deployment.index.ApplicationArchiveBuildStep#build threw an exception: org.jboss.jandex.UnsupportedVersion: Can't read Jandex index from /META-INF/jandex.idx: Can't read index version 12; this IndexReader only supports index versions 2-3,6-11
	at io.quarkus.deployment.index.IndexingUtil$MetaInfJandexReader.apply(IndexingUtil.java:288)
	at io.quarkus.deployment.index.IndexingUtil$MetaInfJandexReader.apply(IndexingUtil.java:264)
	at io.quarkus.paths.PathTreeVisit.process(PathTreeVisit.java:39)
	at io.quarkus.paths.DirectoryPathTree.apply(DirectoryPathTree.java:106)
	at io.quarkus.paths.ArchivePathTree$OpenArchivePathTree.apply(ArchivePathTree.java:203)
	at io.quarkus.paths.PathTreeWithManifest.apply(PathTreeWithManifest.java:74)
	at io.quarkus.deployment.index.IndexingUtil.indexTree(IndexingUtil.java:63)
	at io.quarkus.deployment.index.ApplicationArchiveBuildStep.lambda$addMarkerFilePaths$1(ApplicationArchiveBuildStep.java:244)
	at io.quarkus.bootstrap.classloading.PathTreeClassPathElement.apply(PathTreeClassPathElement.java:114)
	at io.quarkus.deployment.index.ApplicationArchiveBuildStep.addMarkerFilePaths(ApplicationArchiveBuildStep.java:231)
	at io.quarkus.deployment.index.ApplicationArchiveBuildStep.scanForOtherIndexes(ApplicationArchiveBuildStep.java:144)
	at io.quarkus.deployment.index.ApplicationArchiveBuildStep.build(ApplicationArchiveBuildStep.java:105)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:864)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:282)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
	at java.base/java.lang.Thread.run(Thread.java:840)
	at org.jboss.threads.JBossThread.run(JBossThread.java:501)
```