### PR TITLE
ci(cryostat): update repo and tags for renaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ on:
       - v[0-9]+
       - v[0-9]+.[0-9]+
       - cryostat-v[0-9]+.[0-9]+
-      - cryostat3-v[0-9]+.[0-9]+
 
 jobs:
   check-before-build:
@@ -84,7 +83,7 @@ jobs:
           ${{ runner.os }}-
     - uses: actions/checkout@v4
       with:
-        repository: ${{ github.repository_owner }}/cryostat3
+        repository: ${{ github.repository_owner }}/cryostat
         ref: main
         submodules: true
         fetch-depth: 0
@@ -129,19 +128,19 @@ jobs:
       run: systemctl --user enable --now podman.socket
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
-    - name: Build cryostat3
+    - name: Build cryostat
       run: ./mvnw -B -U -Dio.cryostat.core.version=${{ needs.build-core.outputs.core_version }} clean verify
       continue-on-error: ${{ matrix.java != '17' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Debug podman images
       run: podman images
-    - name: Save cryostat3 image
-      run: podman save -o cryostat3.tar --format oci-archive quay.io/cryostat/cryostat:3.0.0-snapshot
+    - name: Save cryostat image
+      run: podman save -o cryostat.tar --format oci-archive quay.io/cryostat/cryostat:latest
     - uses: actions/upload-artifact@v3
       with:
-        name: cryostat3
-        path: ${{ github.workspace }}/cryostat3.tar
+        name: cryostat
+        path: ${{ github.workspace }}/cryostat.tar
 
   push-to-ghcr:
     runs-on: ubuntu-latest
@@ -150,21 +149,21 @@ jobs:
       matrix:
         java: ['17']
     outputs:
-      amd64_image: ${{ steps.cryostat3_amd64_image.outputs.image }}
+      amd64_image: ${{ steps.cryostat_amd64_image.outputs.image }}
 
     permissions:
         packages: write
     steps:
-    - name: Download cryostat3 artifact
+    - name: Download cryostat artifact
       uses: actions/download-artifact@v3
       with:
-        name: cryostat3
-    - name: Load cryostat3 image
-      run: podman load -i cryostat3.tar
-    - name: Tag cryostat3 image
-      run: podman tag cryostat:3.0.0-snapshot ghcr.io/${{ github.repository_owner }}/cryostat-core:pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}-linux-java${{ matrix.java }}
+        name: cryostat
+    - name: Load cryostat image
+      run: podman load -i cryostat.tar
+    - name: Tag cryostat image
+      run: podman tag cryostat:latest ghcr.io/${{ github.repository_owner }}/cryostat-core:pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}-linux-java${{ matrix.java }}
     - name: Push PR test image to ghcr.io
-      id: push-cryostat3-to-ghcr
+      id: push-cryostat-to-ghcr
       uses: redhat-actions/push-to-registry@v2
       with:
         image: cryostat-core
@@ -172,9 +171,9 @@ jobs:
         registry: ghcr.io/${{ github.repository_owner }}
         username: ${{ github.event.pull_request.user.login }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: store cryostat3 images as output
-      id: cryostat3_amd64_image
-      run: echo "image=${{ steps.push-cryostat3-to-ghcr.outputs.registry-path }}" >> "$GITHUB_OUTPUT"
+    - name: store cryostat images as output
+      id: cryostat_amd64_image
+      run: echo "image=${{ steps.push-cryostat-to-ghcr.outputs.registry-path }}" >> "$GITHUB_OUTPUT"
 
   comment-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since renaming the original Cryostat repo to `cryostat-legacy` and Cryostat3 back onto `cryostat`, the CI here has been broken. Here's a failed run: https://github.com/cryostatio/cryostat-core/actions/runs/9542552901/job/26297574264?pr=406