### PR TITLE
feat(diagnostic): add interface method for invoking MBean operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: 'maven'
     - name: maven-settings
@@ -145,7 +145,7 @@ jobs:
     needs: [build-cryostat]
     strategy:
       matrix:
-        java: ['17']
+        java: ['21']
     outputs:
       amd64_image: ${{ steps.cryostat_amd64_image.outputs.image }}
 

--- a/cryostat-core/pom.xml
+++ b/cryostat-core/pom.xml
@@ -149,7 +149,7 @@
   </dependency>
   <dependency>
     <groupId>org.mockito</groupId>
-    <artifactId>mockito-inline</artifactId>
+    <artifactId>mockito-core</artifactId>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -242,7 +242,7 @@
             <exclude>src/main/java/org/openjdk/jmc/**</exclude>
           </excludes>
           <googleJavaFormat>
-            <version>1.15.0</version>
+            <version>1.17.0</version>
             <style>AOSP</style>
             <reflowLongStrings>true</reflowLongStrings>
           </googleJavaFormat>

--- a/cryostat-core/src/main/java/io/cryostat/core/EventOptionsBuilder.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/EventOptionsBuilder.java
@@ -95,7 +95,8 @@ public class EventOptionsBuilder {
 
     public static class Factory {
         public EventOptionsBuilder create(JFRConnection connection)
-                throws IOException, ServiceNotAvailableException,
+                throws IOException,
+                        ServiceNotAvailableException,
                         org.openjdk.jmc.flightrecorder.configuration.FlightRecorderException {
             if (!FlightRecorderServiceV2.isAvailable(connection.getHandle())) {
                 throw new UnsupportedOperationException("Only FlightRecorder V2 is supported");

--- a/cryostat-core/src/main/java/io/cryostat/core/EventOptionsCustomizer.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/EventOptionsCustomizer.java
@@ -41,7 +41,9 @@ public class EventOptionsCustomizer {
     }
 
     public EventOptionsCustomizer set(String typeId, String option, String value)
-            throws FlightRecorderException, EventTypeException, EventOptionException,
+            throws FlightRecorderException,
+                    EventTypeException,
+                    EventOptionException,
                     OptionValueException {
         if (!isInitialized()) {
             initialize();

--- a/cryostat-core/src/main/java/io/cryostat/core/net/CryostatFlightRecorderService.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/CryostatFlightRecorderService.java
@@ -36,15 +36,27 @@ import io.cryostat.libcryostat.templates.Template;
 public interface CryostatFlightRecorderService extends IFlightRecorderService {
 
     IRecordingDescriptor start(IConstrainedMap<String> recordingOptions, Template eventTemplate)
-            throws io.cryostat.core.FlightRecorderException, FlightRecorderException,
-                    ConnectionException, ParseException, IOException, FlightRecorderException,
-                    ServiceNotAvailableException, QuantityConversionException, EventOptionException,
+            throws io.cryostat.core.FlightRecorderException,
+                    FlightRecorderException,
+                    ConnectionException,
+                    ParseException,
+                    IOException,
+                    FlightRecorderException,
+                    ServiceNotAvailableException,
+                    QuantityConversionException,
+                    EventOptionException,
                     EventTypeException;
 
     default IRecordingDescriptor start(IConstrainedMap<String> recordingOptions, String template)
-            throws io.cryostat.core.FlightRecorderException, FlightRecorderException,
-                    ConnectionException, ParseException, IOException, ServiceNotAvailableException,
-                    QuantityConversionException, EventOptionException, EventTypeException {
+            throws io.cryostat.core.FlightRecorderException,
+                    FlightRecorderException,
+                    ConnectionException,
+                    ParseException,
+                    IOException,
+                    ServiceNotAvailableException,
+                    QuantityConversionException,
+                    EventOptionException,
+                    EventTypeException {
         XMLModel model = EventConfiguration.createModel(template);
         IConstrainedMap<EventOptionID> eventOptions =
                 new EventConfiguration(model)

--- a/cryostat-core/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -64,14 +64,21 @@ public interface JFRConnection extends AutoCloseable {
             Object[] params,
             String[] signature,
             Class<T> returnType)
-            throws MalformedObjectNameException, InstanceNotFoundException, MBeanException,
-                    ReflectionException, IOException, ConnectionException {
+            throws MalformedObjectNameException,
+                    InstanceNotFoundException,
+                    MBeanException,
+                    ReflectionException,
+                    IOException,
+                    ConnectionException {
         throw new ConnectionException("Unimplemented");
     }
 
     public MBeanMetrics getMBeanMetrics()
-            throws ConnectionException, IOException, InstanceNotFoundException,
-                    IntrospectionException, ReflectionException;
+            throws ConnectionException,
+                    IOException,
+                    InstanceNotFoundException,
+                    IntrospectionException,
+                    ReflectionException;
 
     public boolean isConnected();
 

--- a/cryostat-core/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
+import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
 import javax.management.ReflectionException;
 import javax.management.remote.JMXServiceURL;
 
@@ -55,6 +57,17 @@ public interface JFRConnection extends AutoCloseable {
     }
 
     public JvmIdentifier getJvmIdentifier() throws IDException, IOException;
+
+    public default <T> T invokeMBeanOperation(
+            String beanName,
+            String operation,
+            Object[] params,
+            String[] signature,
+            Class<T> returnType)
+            throws MalformedObjectNameException, InstanceNotFoundException, MBeanException,
+                    ReflectionException, IOException, ConnectionException {
+        throw new ConnectionException("Unimplemented");
+    }
 
     public MBeanMetrics getMBeanMetrics()
             throws ConnectionException, IOException, InstanceNotFoundException,

--- a/cryostat-core/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
@@ -214,8 +214,12 @@ public class JFRJMXConnection implements JFRConnection {
             Object[] params,
             String[] signature,
             Class<T> returnType)
-            throws MalformedObjectNameException, InstanceNotFoundException, MBeanException,
-                    ReflectionException, IOException, ConnectionException {
+            throws MalformedObjectNameException,
+                    InstanceNotFoundException,
+                    MBeanException,
+                    ReflectionException,
+                    IOException,
+                    ConnectionException {
         if (!isConnected()) {
             connect();
         }
@@ -275,14 +279,18 @@ public class JFRJMXConnection implements JFRConnection {
     }
 
     private Map<String, Object> getAttributeMap(ObjectName beanName)
-            throws InstanceNotFoundException, IntrospectionException, ReflectionException,
+            throws InstanceNotFoundException,
+                    IntrospectionException,
+                    ReflectionException,
                     IOException {
         return getAttributeMap(beanName, m -> true);
     }
 
     private Map<String, Object> getAttributeMap(
             ObjectName beanName, Predicate<MBeanAttributeInfo> attrPredicate)
-            throws InstanceNotFoundException, IntrospectionException, ReflectionException,
+            throws InstanceNotFoundException,
+                    IntrospectionException,
+                    ReflectionException,
                     IOException {
         Map<String, Object> attrMap = new HashMap<>();
 
@@ -313,7 +321,9 @@ public class JFRJMXConnection implements JFRConnection {
     }
 
     public synchronized MBeanMetrics getMBeanMetrics()
-            throws IOException, InstanceNotFoundException, IntrospectionException,
+            throws IOException,
+                    InstanceNotFoundException,
+                    IntrospectionException,
                     ReflectionException {
         if (!isConnected()) {
             connect();

--- a/cryostat-core/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
@@ -31,6 +31,7 @@ import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanException;
+import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
@@ -204,6 +205,24 @@ public class JFRJMXConnection implements JFRConnection {
         } catch (ReflectionException | IntrospectionException | InstanceNotFoundException e) {
             throw new IDException(e);
         }
+    }
+
+    @Override
+    public <T> T invokeMBeanOperation(
+            String beanName,
+            String operation,
+            Object[] params,
+            String[] signature,
+            Class<T> returnType)
+            throws MalformedObjectNameException, InstanceNotFoundException, MBeanException,
+                    ReflectionException, IOException, ConnectionException {
+        if (!isConnected()) {
+            connect();
+        }
+        return (T)
+                this.rjmxConnection
+                        .getMBeanServer()
+                        .invoke(ObjectName.getInstance(beanName), operation, params, signature);
     }
 
     private Map<String, Object> parseCompositeData(CompositeData compositeData) {

--- a/cryostat-core/src/main/java/io/cryostat/core/net/JmxFlightRecorderService.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/JmxFlightRecorderService.java
@@ -230,9 +230,14 @@ public class JmxFlightRecorderService implements CryostatFlightRecorderService {
 
     @Override
     public IRecordingDescriptor start(IConstrainedMap<String> recordingOptions, Template template)
-            throws io.cryostat.core.FlightRecorderException, FlightRecorderException,
-                    ConnectionException, IOException, FlightRecorderException,
-                    ServiceNotAvailableException, QuantityConversionException, EventOptionException,
+            throws io.cryostat.core.FlightRecorderException,
+                    FlightRecorderException,
+                    ConnectionException,
+                    IOException,
+                    FlightRecorderException,
+                    ServiceNotAvailableException,
+                    QuantityConversionException,
+                    EventOptionException,
                     EventTypeException {
         return tryConnect()
                 .start(recordingOptions, enableEvents(template.getName(), template.getType()));
@@ -240,9 +245,14 @@ public class JmxFlightRecorderService implements CryostatFlightRecorderService {
 
     private IConstrainedMap<EventOptionID> enableEvents(
             String templateName, TemplateType templateType)
-            throws ConnectionException, IOException, io.cryostat.core.FlightRecorderException,
-                    FlightRecorderException, ServiceNotAvailableException,
-                    QuantityConversionException, EventOptionException, EventTypeException {
+            throws ConnectionException,
+                    IOException,
+                    io.cryostat.core.FlightRecorderException,
+                    FlightRecorderException,
+                    ServiceNotAvailableException,
+                    QuantityConversionException,
+                    EventOptionException,
+                    EventTypeException {
         if (templateName.equals("ALL")) {
             return enableAllEvents();
         }
@@ -254,8 +264,12 @@ public class JmxFlightRecorderService implements CryostatFlightRecorderService {
     }
 
     private IConstrainedMap<EventOptionID> enableAllEvents()
-            throws ConnectionException, IOException, FlightRecorderException,
-                    ServiceNotAvailableException, QuantityConversionException, EventOptionException,
+            throws ConnectionException,
+                    IOException,
+                    FlightRecorderException,
+                    ServiceNotAvailableException,
+                    QuantityConversionException,
+                    EventOptionException,
                     EventTypeException {
         EventOptionsBuilder builder = new EventOptionsBuilder.Factory().create(conn);
 

--- a/cryostat-core/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/reports/InterruptibleReportGenerator.java
@@ -101,7 +101,9 @@ public class InterruptibleReportGenerator {
 
     private Pair<Collection<IResult>, Long> generateResultHelper(
             InputStream recording, Predicate<IRule> predicate)
-            throws InterruptedException, IOException, ExecutionException,
+            throws InterruptedException,
+                    IOException,
+                    ExecutionException,
                     CouldNotLoadRecordingException {
         Collection<IRule> rules =
                 RuleRegistry.getRules().stream().filter(predicate).collect(Collectors.toList());

--- a/libcryostat/pom.xml
+++ b/libcryostat/pom.xml
@@ -87,7 +87,7 @@
   </dependency>
   <dependency>
     <groupId>org.mockito</groupId>
-    <artifactId>mockito-inline</artifactId>
+    <artifactId>mockito-core</artifactId>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -177,7 +177,7 @@
       <configuration>
         <java>
           <googleJavaFormat>
-            <version>1.15.0</version>
+            <version>1.17.0</version>
             <style>AOSP</style>
             <reflowLongStrings>true</reflowLongStrings>
           </googleJavaFormat>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
   <com.github.spotbugs.plugin.version>4.8.6.4</com.github.spotbugs.plugin.version>
   <org.junit.jupiter.version>5.11.1</org.junit.jupiter.version>
   <org.hamcrest.version>3.0</org.hamcrest.version>
-  <org.mockito.version>5.2.0</org.mockito.version>
+  <org.mockito.version>5.14.1</org.mockito.version>
   <org.jacoco.maven.plugin.version>0.8.12</org.jacoco.maven.plugin.version>
   <com.diffplug.spotless.maven.plugin.version>2.43.0</com.diffplug.spotless.maven.plugin.version>
   <org.slf4j.version>2.0.16</org.slf4j.version>
@@ -152,7 +152,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${org.mockito.version}</version>
       <scope>test</scope>
     </dependency>
@@ -279,7 +279,7 @@
             <exclude>src/main/java/org/openjdk/jmc/**</exclude>
           </excludes>
           <googleJavaFormat>
-            <version>1.15.0</version>
+            <version>1.17.0</version>
             <style>AOSP</style>
             <reflowLongStrings>true</reflowLongStrings>
           </googleJavaFormat>


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/133

Adds an interface method for invoking MBean operations, and a default implementation for doing this over JMX connections that simply wraps around the existing MBeanServerConnection.
