### PR TITLE
feat(templates): add preset event template type

### DIFF
--- a/libcryostat/src/main/java/io/cryostat/libcryostat/templates/TemplateType.java
+++ b/libcryostat/src/main/java/io/cryostat/libcryostat/templates/TemplateType.java
@@ -18,5 +18,6 @@ package io.cryostat.libcryostat.templates;
 public enum TemplateType {
     TARGET,
     CUSTOM,
+    PRESET,
     ;
 }


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/548

Adds a third event template type, `PRESET`. These are intended to be pre-loaded `.jfc` files that ship with Cryostat, somewhat akin to Custom event templates, except that Custom templates are explicitly mutable by the end user(s) and can be created or deleted at runtime. Presets ship with Cryostat and are immutable for the user.