### PR TITLE
ci(criu): add CRIU PPA for Podman dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
         cd src/main/webui
         yarn install && yarn yarn:frzinstall
         cd -
+    - name: Add CRIU PPA
+      run: sudo add-apt-repository ppa:criu/ppa && sudo apt update
     - name: Install podman v4
       run: |
         echo "deb $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list


### PR DESCRIPTION
See https://github.com/cryostatio/cryostat-core/pull/493
https://github.com/cryostatio/cryostat-core/actions/runs/12653781969/job/35260363394?pr=493

The CI runner `ubuntu-latest` has moved to pointing to 24.04, which doesn't have `criu` in the repositories currently: https://github.com/checkpoint-restore/criu/issues/2404
