### PR TITLE
chore(pom): use project.version property for libcryostat

### DIFF
--- a/cryostat-core/pom.xml
+++ b/cryostat-core/pom.xml
@@ -53,7 +53,7 @@
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   <java.version>17</java.version>
-  <io.cryostat.libcryostat.version>4.1.0-SNAPSHOT</io.cryostat.libcryostat.version>
+  <io.cryostat.libcryostat.version>${project.version}</io.cryostat.libcryostat.version>
   <org.openjdk.jmc.version>9.1.0</org.openjdk.jmc.version>
   <org.jsoup.version>1.21.1</org.jsoup.version>
 </properties>


### PR DESCRIPTION
This makes it easier on downstream tooling that needs to do version manipulation.