### PR TITLE
feat(diagnostics): Pass along job Id for invoking mbean operations

### DIFF
--- a/cryostat-core/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -63,7 +63,8 @@ public interface JFRConnection extends AutoCloseable {
             String operation,
             Object[] params,
             String[] signature,
-            Class<T> returnType)
+            Class<T> returnType,
+            String requestId)
             throws MalformedObjectNameException,
                     InstanceNotFoundException,
                     MBeanException,

--- a/cryostat-core/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
@@ -213,7 +213,8 @@ public class JFRJMXConnection implements JFRConnection {
             String operation,
             Object[] params,
             String[] signature,
-            Class<T> returnType)
+            Class<T> returnType,
+            String jobId)
             throws MalformedObjectNameException,
                     InstanceNotFoundException,
                     MBeanException,


### PR DESCRIPTION
Fixes https://github.com/cryostatio/cryostat/issues/134

See also https://github.com/cryostatio/cryostat/pull/984#discussion_r2345062309

Hi,

Simple PR to allow passing along the job/request ID for mbean invocations. Allows the server to verify which request an upload was for and emit notifications accordingly.
