### PR TITLE
fix(mbean): Calculate metrics that aren't actually mbean attributes

### DIFF
--- a/libcryostat/src/main/java/io/cryostat/libcryostat/net/MemoryMetrics.java
+++ b/libcryostat/src/main/java/io/cryostat/libcryostat/net/MemoryMetrics.java
@@ -45,7 +45,7 @@ public class MemoryMetrics {
         this.objectPendingFinalizationCount =
                 (int) attributes.getOrDefault("ObjectPendingFinalizationCount", Integer.MIN_VALUE);
 
-        // these are metrics that we won't be able
+        // these are metrics synthetic attributes that we won't be able
         // to fetch from the mbean like this. Instead we calculate it here.
         this.heapMemoryUsagePercent =
                 (double) this.heapMemoryUsage.getUsed()

--- a/libcryostat/src/main/java/io/cryostat/libcryostat/net/MemoryMetrics.java
+++ b/libcryostat/src/main/java/io/cryostat/libcryostat/net/MemoryMetrics.java
@@ -44,11 +44,16 @@ public class MemoryMetrics {
                                         "NonHeapMemoryUsage", new MemoryUsage(-1, 0, 0, -1)));
         this.objectPendingFinalizationCount =
                 (int) attributes.getOrDefault("ObjectPendingFinalizationCount", Integer.MIN_VALUE);
-        this.freeHeapMemory = (long) attributes.getOrDefault("FreeHeapMemory", Long.MIN_VALUE);
-        this.freeNonHeapMemory =
-                (long) attributes.getOrDefault("FreeNonHeapMemory", Long.MIN_VALUE);
+
+        // these are metrics that we won't be able
+        // to fetch from the mbean like this. Instead we calculate it here.
         this.heapMemoryUsagePercent =
-                (double) attributes.getOrDefault("HeapMemoryUsagePercent", Double.MIN_VALUE);
+                (double) this.heapMemoryUsage.getUsed()
+                        / (double) this.heapMemoryUsage.getCommitted();
+        this.freeHeapMemory = this.heapMemoryUsage.getCommitted() - this.heapMemoryUsage.getUsed();
+        this.freeNonHeapMemory =
+                this.nonHeapMemoryUsage.getCommitted() - this.nonHeapMemoryUsage.getUsed();
+
         this.verbose = (boolean) attributes.getOrDefault("Verbose", false);
     }
 


### PR DESCRIPTION
Fixes https://github.com/cryostatio/cryostat/issues/649

The FreeHeapMemory, FreeNonHeapMemory, and HeapMemoryUsagePercent attributes are all defined as synthetic metrics within JMC. This means rather than being retrieved from the mbeans directly they're instead calculated from other values. Their definitions (along with a few others however we don't use/implement those) are found in the plugin.xml for rjmx (https://github.com/openjdk/jmc/blob/181b8a030c9d54104389318df575e7931df08d93/application/org.openjdk.jmc.rjmx/plugin.xml#L123).

For applications using the agent we already do this calculation, for the ones over JMX this goes through cryostat-core instead where we rely on RJMXConnection, which tries to retrieve them from the MbeanServer. Since they aren't actually attributes this would then cause us to use the defaults instead, resulting in the bug.

This brings the cryostat-core/jmx method in line with the agent and calculates the relevant attributes.

To test:

- Build this PR
- Build cryostat with this version of cryostat-core
- bash smoketest.bash -O -t quarkus-cryostat-agent -A
- Create a heapMemoryUsagePercent mbean metrics card on the dashboard, check that it works the same for both agent and jmx connections
- Inspect the network traffic, check that the graphql endpoint is returning normal values.