### PR TITLE
feat(triggers): Add support for querying mbean attributes

### DIFF
--- a/cryostat-core/src/main/java/io/cryostat/core/net/JFRConnection.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/JFRConnection.java
@@ -33,6 +33,7 @@ import io.cryostat.core.templates.TemplateService;
 import io.cryostat.libcryostat.JvmIdentifier;
 import io.cryostat.libcryostat.net.IDException;
 import io.cryostat.libcryostat.net.MBeanMetrics;
+import io.cryostat.libcryostat.net.MbeanAttributeMap;
 import io.cryostat.libcryostat.sys.Clock;
 import io.cryostat.libcryostat.triggers.SmartTrigger;
 
@@ -86,6 +87,12 @@ public interface JFRConnection extends AutoCloseable {
     public default void disableSmartTrigger(String definitions) throws ConnectionException {
         throw new ConnectionException("Unimplemented");
     }
+
+    public List<MbeanAttributeMap> queryMbeanAttributes()
+            throws IOException,
+                    InstanceNotFoundException,
+                    IntrospectionException,
+                    ReflectionException;
 
     public MBeanMetrics getMBeanMetrics()
             throws ConnectionException,

--- a/cryostat-core/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
+++ b/cryostat-core/src/main/java/io/cryostat/core/net/JFRJMXConnection.java
@@ -31,7 +31,9 @@ import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanException;
+import javax.management.MBeanInfo;
 import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
@@ -62,6 +64,8 @@ import io.cryostat.core.templates.TemplateService;
 import io.cryostat.libcryostat.JvmIdentifier;
 import io.cryostat.libcryostat.net.IDException;
 import io.cryostat.libcryostat.net.MBeanMetrics;
+import io.cryostat.libcryostat.net.MbeanAttributeMap;
+import io.cryostat.libcryostat.net.MbeanAttributeMap.MBeanAttribute;
 import io.cryostat.libcryostat.net.MemoryMetrics;
 import io.cryostat.libcryostat.net.OperatingSystemMetrics;
 import io.cryostat.libcryostat.net.RuntimeMetrics;
@@ -427,5 +431,35 @@ public class JFRJMXConnection implements JFRConnection {
         public ConnectionFailureException(String message) {
             super(message);
         }
+    }
+
+    @Override
+    public synchronized List<MbeanAttributeMap> queryMbeanAttributes()
+            throws IOException,
+                    InstanceNotFoundException,
+                    IntrospectionException,
+                    ReflectionException {
+        if (!isConnected()) {
+            connect();
+        }
+        List<MbeanAttributeMap> attributeMap = new ArrayList<MbeanAttributeMap>();
+        // null,null returns all Mbeans
+        Set<ObjectInstance> beans = rjmxConnection.getMBeanServer().queryMBeans(null, null);
+        for (ObjectInstance bean : beans) {
+            List<MBeanAttribute> attrs = new ArrayList<>();
+            MBeanInfo info = rjmxConnection.getMBeanServer().getMBeanInfo(bean.getObjectName());
+            for (MBeanAttributeInfo a : info.getAttributes()) {
+                attrs.add(
+                        new MBeanAttribute(
+                                a.getName(),
+                                a.getType(),
+                                a.getDescription(),
+                                bean.getClassName(),
+                                a.isReadable(),
+                                a.isWritable()));
+            }
+            attributeMap.add(new MbeanAttributeMap(bean.getClassName(), attrs));
+        }
+        return attributeMap;
     }
 }

--- a/libcryostat/src/main/java/io/cryostat/libcryostat/net/MbeanAttributeMap.java
+++ b/libcryostat/src/main/java/io/cryostat/libcryostat/net/MbeanAttributeMap.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.libcryostat.net;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MbeanAttributeMap {
+
+    private String mBeanName;
+    private List<MBeanAttribute> attributes;
+
+    public MbeanAttributeMap(String name, List<MBeanAttribute> attrs) {
+        this.mBeanName = name;
+        this.attributes = new ArrayList<MBeanAttribute>(attrs);
+    }
+
+    // Default Constructor for ObjectMapper deserialization
+    public MbeanAttributeMap() {
+        this("", Collections.emptyList());
+    }
+
+    public String getMbeanName() {
+        return mBeanName;
+    }
+
+    public List<MBeanAttribute> getAttributes() {
+        return Collections.unmodifiableList(attributes);
+    }
+
+    public void setMbeanName(String mbeanName) {
+        this.mBeanName = mbeanName;
+    }
+
+    public void setAttributes(List<MBeanAttribute> attributes) {
+        this.attributes = new ArrayList<MBeanAttribute>(attributes);
+    }
+
+    public static class MBeanAttribute {
+
+        private String name;
+        private String type;
+        private String description;
+        private String parentBean;
+        private boolean isReadable;
+        private boolean isWritable;
+
+        public MBeanAttribute(
+                String name,
+                String type,
+                String description,
+                String parentBean,
+                boolean isReadable,
+                boolean isWritable) {
+            this.name = name;
+            this.type = type;
+            this.description = description;
+            this.parentBean = parentBean;
+            this.isReadable = isReadable;
+            this.isWritable = isWritable;
+        }
+
+        // Default constructor for ObjectMapper deserialization
+        public MBeanAttribute() {
+            this("", "", "", "", false, false);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public String getParentBean() {
+            return parentBean;
+        }
+
+        public void setParentBean(String parentBean) {
+            this.parentBean = parentBean;
+        }
+
+        public boolean isReadable() {
+            return isReadable;
+        }
+
+        public void setIsReadable(boolean isReadable) {
+            this.isReadable = isReadable;
+        }
+
+        public boolean isWritable() {
+            return isWritable;
+        }
+
+        public void setIsWritable(boolean isWritable) {
+            this.isWritable = isWritable;
+        }
+    }
+}


### PR DESCRIPTION
Related to: https://github.com/cryostatio/cryostat-web/issues/2092

Adds methods to JFRConnection, JFRJMXConnection to support the new endpoints for querying mbeans. Also adds the MbeanAttributeMap and MbeanAttribute classes to libcryostat as they're used across both agent and server.