### PR TITLE
ci(pr): remove test image publication, drop to pull_request event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -132,69 +132,3 @@ jobs:
             clean verify
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Save cryostat image
-      run: podman save -o cryostat.tar --format oci-archive quay.io/cryostat/cryostat:latest
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: cryostat
-        path: ${{ github.workspace }}/cryostat.tar
-
-  push-to-ghcr:
-    runs-on: ubuntu-latest
-    needs: [build-cryostat]
-    strategy:
-      matrix:
-        java: ['25']
-    outputs:
-      amd64_image: ${{ steps.cryostat_amd64_image.outputs.image }}
-
-    permissions:
-        packages: write
-    steps:
-    - name: Download cryostat artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: cryostat
-    - name: Load cryostat image
-      run: podman load -i cryostat.tar
-    - name: Tag cryostat image
-      run: podman tag cryostat:latest ghcr.io/${{ github.repository_owner }}/cryostat-core:pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}-linux
-    - name: Push PR test image to ghcr.io
-      id: push-cryostat-to-ghcr
-      uses: redhat-actions/push-to-registry@9986a6552bc4571882a4a67e016b17361412b4df # v2.7.1
-      with:
-        image: cryostat-core
-        tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}-linux
-        registry: ghcr.io/${{ github.repository_owner }}
-        username: ${{ github.event.pull_request.user.login }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: store cryostat images as output
-      id: cryostat_amd64_image
-      run: echo "image=${{ steps.push-cryostat-to-ghcr.outputs.registry-path }}" >> "$GITHUB_OUTPUT"
-
-  comment-image:
-    runs-on: ubuntu-latest
-    needs: [push-to-ghcr]
-    env:
-      amd64_image: ${{ needs.push-to-ghcr.outputs.amd64_image }}
-
-    permissions:
-      pull-requests: write
-    steps:
-    - name: Create markdown table
-      id: md-table
-      uses: petems/csv-to-md-table-action@401501a2cdf2512164c1be3b70411976a2b838b9 # v4.0.0
-      with:
-        csvinput: |
-          ARCH, IMAGE
-          amd64, ${{ env.amd64_image }}
-
-    - uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-      with:
-        message: |-
-          ${{ steps.md-table.outputs.markdown-table }}
-
-          To run smoketest:
-          ```
-          CRYOSTAT_IMAGE=${{ env.amd64_image }} bash smoketest.bash
-          ```


### PR DESCRIPTION
See #664

Drops the `pull_request_target` down to `pull_request` and removes the steps that required additional permissions: pushing a Cryostat image built with the new -core to ghcr.io and commenting the link to it. cryostat-core is now a very slow-moving project compared to what it was when that CI was set up, and the Cryostat test suite covers more than it used to, so the automated testing remaining here should be sufficient to ensure there are no regressions in -core PRs. Typically now any -core PR is adding a new feature to be built upon in Cryostat or cryostat-reports or cryostat-agent, so reviewers must manually combine the right pieces together for manual testing during the review process anyway.
