### PR TITLE
chore(dependencies): upgrade google-java-format to 1.35.0

### DIFF
--- a/cryostat-core/pom.xml
+++ b/cryostat-core/pom.xml
@@ -56,6 +56,7 @@
   <io.cryostat.libcryostat.version>${project.version}</io.cryostat.libcryostat.version>
   <org.openjdk.jmc.version>9.1.2</org.openjdk.jmc.version>
   <org.jsoup.version>1.22.2</org.jsoup.version>
+  <com.google.java-format.version>1.35.0</com.google.java-format.version>
 </properties>
 <dependencies>
   <dependency>
@@ -241,7 +242,7 @@
             <exclude>src/main/java/org/openjdk/jmc/**</exclude>
           </excludes>
           <googleJavaFormat>
-            <version>1.17.0</version>
+            <version>${com.google.java-format.version}</version>
             <style>AOSP</style>
             <reflowLongStrings>true</reflowLongStrings>
           </googleJavaFormat>

--- a/libcryostat/pom.xml
+++ b/libcryostat/pom.xml
@@ -47,6 +47,7 @@
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   <java.version>11</java.version>
+  <com.google.java-format.version>1.35.0</com.google.java-format.version>
 </properties>
 
 <dependencies>
@@ -177,7 +178,7 @@
       <configuration>
         <java>
           <googleJavaFormat>
-            <version>1.17.0</version>
+            <version>${com.google.java-format.version}</version>
             <style>AOSP</style>
             <reflowLongStrings>true</reflowLongStrings>
           </googleJavaFormat>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
   <org.mockito.version>5.23.0</org.mockito.version>
   <org.jacoco.maven.plugin.version>0.8.15</org.jacoco.maven.plugin.version>
   <com.diffplug.spotless.maven.plugin.version>3.9.0</com.diffplug.spotless.maven.plugin.version>
+  <com.google.java-format.version>1.35.0</com.google.java-format.version>
   <org.slf4j.version>2.0.18</org.slf4j.version>
 
   <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
@@ -279,7 +280,7 @@
             <exclude>src/main/java/org/openjdk/jmc/**</exclude>
           </excludes>
           <googleJavaFormat>
-            <version>1.17.0</version>
+            <version>${com.google.java-format.version}</version>
             <style>AOSP</style>
             <reflowLongStrings>true</reflowLongStrings>
           </googleJavaFormat>


### PR DESCRIPTION
See cryostatio/cryostat#1538

Since upgrading development machines to JDK 25, the old google-java-format version no longer works.
